### PR TITLE
Add null graphics device

### DIFF
--- a/Pie/GraphicsApi.cs
+++ b/Pie/GraphicsApi.cs
@@ -20,7 +20,12 @@ public enum GraphicsApi
     /// <summary>
     /// !EXPERIMENTAL! Vulkan
     /// </summary>
-    Vulkan
+    Vulkan,
+
+    /// <summary>
+    /// Null
+    /// </summary>
+    Null
 }
 
 public static class GraphicsApiExtensions

--- a/Pie/GraphicsDevice.cs
+++ b/Pie/GraphicsDevice.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 using System.Numerics;
 using Pie.Direct3D11;
+using Pie.Null;
 using Pie.OpenGL;
 using Pie.Vulkan;
 using Silk.NET.Core.Contexts;
@@ -470,6 +471,15 @@ public abstract class GraphicsDevice : IDisposable
     public static GraphicsDevice CreateVulkan()
     {
         return new VkGraphicsDevice();
+    }
+
+    /// <summary>
+    /// Create a null graphics device.
+    /// </summary>
+    /// <returns>The created graphics device.</returns>
+    public static GraphicsDevice CreateNull()
+    {
+        return new NullGraphicsDevice();
     }
 
     /// <summary>

--- a/Pie/Null/NullBlendState.cs
+++ b/Pie/Null/NullBlendState.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Pie.Null;
+
+internal class NullBlendState : BlendState
+{
+    public override bool IsDisposed { get; protected set; }
+    public override BlendStateDescription Description { get; }
+
+    public override void Dispose()
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        IsDisposed = true;
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Pie/Null/NullBlendState.cs
+++ b/Pie/Null/NullBlendState.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Pie.Null;
 
-internal class NullBlendState : BlendState
+internal sealed class NullBlendState : BlendState
 {
     public override bool IsDisposed { get; protected set; }
     public override BlendStateDescription Description { get; }

--- a/Pie/Null/NullDepthState.cs
+++ b/Pie/Null/NullDepthState.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Pie.Null;
+
+internal class NullDepthState : DepthState
+{
+    public override bool IsDisposed { get; protected set; }
+    public override DepthStateDescription Description { get; }
+
+    public override void Dispose()
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        IsDisposed = true;
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Pie/Null/NullDepthState.cs
+++ b/Pie/Null/NullDepthState.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Pie.Null;
 
-internal class NullDepthState : DepthState
+internal sealed class NullDepthState : DepthState
 {
     public override bool IsDisposed { get; protected set; }
     public override DepthStateDescription Description { get; }

--- a/Pie/Null/NullFramebuffer.cs
+++ b/Pie/Null/NullFramebuffer.cs
@@ -3,7 +3,7 @@ using System.Drawing;
 
 namespace Pie.Null;
 
-internal class NullFramebuffer : Framebuffer
+internal sealed class NullFramebuffer : Framebuffer
 {
     public override bool IsDisposed { get; protected set; }
     public override Size Size { get; set; }

--- a/Pie/Null/NullFramebuffer.cs
+++ b/Pie/Null/NullFramebuffer.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Drawing;
+
+namespace Pie.Null;
+
+internal class NullFramebuffer : Framebuffer
+{
+    public override bool IsDisposed { get; protected set; }
+    public override Size Size { get; set; }
+
+    public override void Dispose()
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        IsDisposed = true;
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Pie/Null/NullGraphicsBuffer.cs
+++ b/Pie/Null/NullGraphicsBuffer.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Pie.Null;
+
+internal class NullGraphicsBuffer : GraphicsBuffer
+{
+    public override bool IsDisposed { get; protected set; }
+
+    public override void Dispose()
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        IsDisposed = true;
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Pie/Null/NullGraphicsBuffer.cs
+++ b/Pie/Null/NullGraphicsBuffer.cs
@@ -9,12 +9,9 @@ internal sealed class NullGraphicsBuffer : GraphicsBuffer
 
     public readonly IntPtr Data;
 
-    private readonly bool owned;
-
-    public NullGraphicsBuffer(IntPtr data, bool owned)
+    public NullGraphicsBuffer(IntPtr data)
     {
         Data = data;
-        this.owned = owned;
     }
 
     public override void Dispose()
@@ -26,11 +23,7 @@ internal sealed class NullGraphicsBuffer : GraphicsBuffer
 
         IsDisposed = true;
 
-        if (owned)
-        {
-            Marshal.FreeHGlobal(Data);
-        }
-
+        Marshal.FreeHGlobal(Data);
         GC.SuppressFinalize(this);
     }
 }

--- a/Pie/Null/NullGraphicsBuffer.cs
+++ b/Pie/Null/NullGraphicsBuffer.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Pie.Null;
 
-internal class NullGraphicsBuffer : GraphicsBuffer
+internal sealed class NullGraphicsBuffer : GraphicsBuffer
 {
     public override bool IsDisposed { get; protected set; }
 

--- a/Pie/Null/NullGraphicsBuffer.cs
+++ b/Pie/Null/NullGraphicsBuffer.cs
@@ -1,10 +1,21 @@
 using System;
+using System.Runtime.InteropServices;
 
 namespace Pie.Null;
 
 internal sealed class NullGraphicsBuffer : GraphicsBuffer
 {
     public override bool IsDisposed { get; protected set; }
+
+    public readonly IntPtr Data;
+
+    private readonly bool owned;
+
+    public NullGraphicsBuffer(IntPtr data, bool owned)
+    {
+        Data = data;
+        this.owned = owned;
+    }
 
     public override void Dispose()
     {
@@ -14,6 +25,11 @@ internal sealed class NullGraphicsBuffer : GraphicsBuffer
         }
 
         IsDisposed = true;
+
+        if (owned)
+        {
+            Marshal.FreeHGlobal(Data);
+        }
 
         GC.SuppressFinalize(this);
     }

--- a/Pie/Null/NullGraphicsDevice.cs
+++ b/Pie/Null/NullGraphicsDevice.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Drawing;
+using System.Numerics;
+
+namespace Pie.Null;
+
+internal class NullGraphicsDevice : GraphicsDevice
+{
+    public override GraphicsApi Api => GraphicsApi.Null;
+
+    public override Swapchain Swapchain { get; }
+
+    public override GraphicsAdapter Adapter { get;  }
+
+    public override Rectangle Viewport { get; set; }
+    public override Rectangle Scissor { get; set; }
+
+    public NullGraphicsDevice()
+    {
+        Swapchain = new Swapchain();
+        Adapter = new GraphicsAdapter("Null");
+    }
+
+    public override void Clear(Color color, ClearFlags flags = ClearFlags.None)
+    {
+    }
+
+    public override void Clear(Vector4 color, ClearFlags flags = ClearFlags.None)
+    {
+    }
+
+    public override void Clear(ClearFlags flags)
+    {
+    }
+
+    public override BlendState CreateBlendState(BlendStateDescription description)
+    {
+        return new NullBlendState();
+    }
+
+    public override GraphicsBuffer CreateBuffer<T>(BufferType bufferType, T[] data, bool dynamic = false)
+    {
+        return new NullGraphicsBuffer();
+    }
+
+    public override GraphicsBuffer CreateBuffer<T>(BufferType bufferType, T data, bool dynamic = false)
+    {
+        return new NullGraphicsBuffer();
+    }
+
+    public override GraphicsBuffer CreateBuffer(BufferType bufferType, uint sizeInBytes, bool dynamic = false)
+    {
+        return new NullGraphicsBuffer();
+    }
+
+    public override GraphicsBuffer CreateBuffer(BufferType bufferType, uint sizeInBytes, IntPtr data, bool dynamic = false)
+    {
+        return new NullGraphicsBuffer();
+    }
+
+    public override unsafe GraphicsBuffer CreateBuffer(BufferType bufferType, uint sizeInBytes, void* data, bool dynamic = false)
+    {
+        return new NullGraphicsBuffer();
+    }
+
+    public override DepthState CreateDepthState(DepthStateDescription description)
+    {
+        return new NullDepthState();
+    }
+
+    public override Framebuffer CreateFramebuffer(params FramebufferAttachment[] attachments)
+    {
+        return new NullFramebuffer();
+    }
+
+    public override InputLayout CreateInputLayout(params InputLayoutDescription[] inputLayoutDescriptions)
+    {
+        return new NullInputLayout();
+    }
+
+    public override RasterizerState CreateRasterizerState(RasterizerStateDescription description)
+    {
+        return new NullRasterizerState();
+    }
+
+    public override SamplerState CreateSamplerState(SamplerStateDescription description)
+    {
+        return new NullSamplerState();
+    }
+
+    public override Shader CreateShader(params ShaderAttachment[] attachments)
+    {
+        return new NullShader();
+    }
+
+    public override Texture CreateTexture(TextureDescription description)
+    {
+        return new NullTexture();
+    }
+
+    public override Texture CreateTexture<T>(TextureDescription description, T[] data)
+    {
+        return new NullTexture();
+    }
+
+    public override Texture CreateTexture<T>(TextureDescription description, T[][] data)
+    {
+        return new NullTexture();
+    }
+
+    public override Texture CreateTexture(TextureDescription description, IntPtr data)
+    {
+        return new NullTexture();
+    }
+
+    public override unsafe Texture CreateTexture(TextureDescription description, void* data)
+    {
+        return new NullTexture();
+    }
+
+    public override void Dispatch(uint groupCountX, uint groupCountY, uint groupCountZ)
+    {
+    }
+
+    public override void Dispose()
+    {
+    }
+
+    public override void Draw(uint vertexCount)
+    {
+    }
+
+    public override void Draw(uint vertexCount, int startVertex)
+    {
+    }
+
+    public override void DrawIndexed(uint indexCount)
+    {
+    }
+
+    public override void DrawIndexed(uint indexCount, int startIndex)
+    {
+    }
+
+    public override void DrawIndexed(uint indexCount, int startIndex, int baseVertex)
+    {
+    }
+
+    public override void DrawIndexedInstanced(uint indexCount, uint instanceCount)
+    {
+    }
+
+    public override void Flush()
+    {
+    }
+
+    public override void GenerateMipmaps(Texture texture)
+    {
+    }
+
+    public override IntPtr MapBuffer(GraphicsBuffer buffer, MapMode mode)
+    {
+        return IntPtr.Zero;
+    }
+
+    public override void Present(int swapInterval)
+    {
+    }
+
+    public override void ResizeSwapchain(Size newSize)
+    {
+    }
+
+    public override void SetBlendState(BlendState state)
+    {
+    }
+
+    public override void SetDepthState(DepthState state)
+    {
+    }
+
+    public override void SetFramebuffer(Framebuffer framebuffer)
+    {
+    }
+
+    public override void SetIndexBuffer(GraphicsBuffer buffer, IndexType type)
+    {
+    }
+
+    public override void SetPrimitiveType(PrimitiveType type)
+    {
+    }
+
+    public override void SetRasterizerState(RasterizerState state)
+    {
+    }
+
+    public override void SetShader(Shader shader)
+    {
+    }
+
+    public override void SetTexture(uint bindingSlot, Texture texture, SamplerState samplerState)
+    {
+    }
+
+    public override void SetUniformBuffer(uint bindingSlot, GraphicsBuffer buffer)
+    {
+    }
+
+    public override void SetVertexBuffer(uint slot, GraphicsBuffer buffer, uint stride, InputLayout layout)
+    {
+    }
+
+    public override void UnmapBuffer(GraphicsBuffer buffer)
+    {
+    }
+
+    public override void UpdateBuffer<T>(GraphicsBuffer buffer, uint offsetInBytes, T[] data)
+    {
+    }
+
+    public override void UpdateBuffer<T>(GraphicsBuffer buffer, uint offsetInBytes, T data)
+    {
+    }
+
+    public override void UpdateBuffer(GraphicsBuffer buffer, uint offsetInBytes, uint sizeInBytes, IntPtr data)
+    {
+    }
+
+    public override unsafe void UpdateBuffer(GraphicsBuffer buffer, uint offsetInBytes, uint sizeInBytes, void* data)
+    {
+    }
+
+    public override void UpdateTexture<T>(Texture texture, int mipLevel, int arrayIndex, int x, int y, int z, int width, int height, int depth, T[] data)
+    {
+    }
+
+    public override void UpdateTexture(Texture texture, int mipLevel, int arrayIndex, int x, int y, int z, int width, int height, int depth, IntPtr data)
+    {
+    }
+
+    public override unsafe void UpdateTexture(Texture texture, int mipLevel, int arrayIndex, int x, int y, int z, int width, int height, int depth, void* data)
+    {
+    }
+}

--- a/Pie/Null/NullGraphicsDevice.cs
+++ b/Pie/Null/NullGraphicsDevice.cs
@@ -4,7 +4,7 @@ using System.Numerics;
 
 namespace Pie.Null;
 
-internal class NullGraphicsDevice : GraphicsDevice
+internal sealed class NullGraphicsDevice : GraphicsDevice
 {
     public override GraphicsApi Api => GraphicsApi.Null;
 

--- a/Pie/Null/NullInputLayout.cs
+++ b/Pie/Null/NullInputLayout.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Pie.Null;
+
+internal class NullInputLayout : InputLayout
+{
+    public override bool IsDisposed { get; protected set; }
+    public override InputLayoutDescription[] Descriptions { get; } = Array.Empty<InputLayoutDescription>();
+
+    public override void Dispose()
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        IsDisposed = true;
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Pie/Null/NullInputLayout.cs
+++ b/Pie/Null/NullInputLayout.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Pie.Null;
 
-internal class NullInputLayout : InputLayout
+internal sealed class NullInputLayout : InputLayout
 {
     public override bool IsDisposed { get; protected set; }
     public override InputLayoutDescription[] Descriptions { get; } = Array.Empty<InputLayoutDescription>();

--- a/Pie/Null/NullRasterizerState.cs
+++ b/Pie/Null/NullRasterizerState.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Pie.Null;
 
-internal class NullRasterizerState : RasterizerState
+internal sealed class NullRasterizerState : RasterizerState
 {
     public override bool IsDisposed { get; protected set; }
     public override RasterizerStateDescription Description { get; }

--- a/Pie/Null/NullRasterizerState.cs
+++ b/Pie/Null/NullRasterizerState.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Pie.Null;
+
+internal class NullRasterizerState : RasterizerState
+{
+    public override bool IsDisposed { get; protected set; }
+    public override RasterizerStateDescription Description { get; }
+
+    public override void Dispose()
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        IsDisposed = true;
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Pie/Null/NullSamplerState.cs
+++ b/Pie/Null/NullSamplerState.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Pie.Null;
+
+internal class NullSamplerState : SamplerState
+{
+    public override bool IsDisposed { get; protected set; }
+    public override SamplerStateDescription Description { get; }
+
+    public override void Dispose()
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        IsDisposed = true;
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Pie/Null/NullSamplerState.cs
+++ b/Pie/Null/NullSamplerState.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Pie.Null;
 
-internal class NullSamplerState : SamplerState
+internal sealed class NullSamplerState : SamplerState
 {
     public override bool IsDisposed { get; protected set; }
     public override SamplerStateDescription Description { get; }

--- a/Pie/Null/NullShader.cs
+++ b/Pie/Null/NullShader.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Pie.Null;
 
-internal class NullShader : Shader
+internal sealed class NullShader : Shader
 {
     public override bool IsDisposed { get; protected set; }
 

--- a/Pie/Null/NullShader.cs
+++ b/Pie/Null/NullShader.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Pie.Null;
+
+internal class NullShader : Shader
+{
+    public override bool IsDisposed { get; protected set; }
+
+    public override void Dispose()
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        IsDisposed = true;
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Pie/Null/NullTexture.cs
+++ b/Pie/Null/NullTexture.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Pie.Null;
 
-internal class NullTexture : Texture
+internal sealed class NullTexture : Texture
 {
     public override bool IsDisposed { get; protected set; }
     public override TextureDescription Description { get; set; }

--- a/Pie/Null/NullTexture.cs
+++ b/Pie/Null/NullTexture.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Pie.Null;
+
+internal class NullTexture : Texture
+{
+    public override bool IsDisposed { get; protected set; }
+    public override TextureDescription Description { get; set; }
+
+    public override void Dispose()
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        IsDisposed = true;
+
+        GC.SuppressFinalize(this);
+    }
+}


### PR DESCRIPTION
This adds `NullGraphicsDevice` and other prerequisite classes which implement no-op methods. This is to allow a graphics device to exist for systems like CI or headless windows.