### PR TITLE
Add better testing and reporting workflow for dotnet projects

### DIFF
--- a/.github/workflows/dotnet-report.yml
+++ b/.github/workflows/dotnet-report.yml
@@ -1,0 +1,23 @@
+name: Report
+on:
+    workflow_run:
+        workflows: [ 'Test' ]
+        branches:
+            - '*'
+        types:
+            - completed
+
+jobs:
+    report:
+        name: Report
+        runs-on: ubuntu-latest
+        if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
+        steps:
+            - name: Report
+              uses: dorny/test-reporter@v1
+              with:
+                  artifact: /TestResults-(.*)/
+                  name: Test Results ($1)
+                  path: "*.trx"
+                  reporter: dotnet-trx
+                  fail-on-error: false

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,24 +1,49 @@
-name: Build Pie
-
+name: Test
 on:
   push:
-    branches: [ "master" ]
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
   pull_request:
-    branches: [ "master" ]
+     branches:
+       - '*'
+     tags-ignore:
+       - '*'
+
+env:
+  PROJECT_NAME: Pie
+  PROJECTS_TESTS_NAME: Pie.Tests
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  test:
+    name: Test
+    runs-on: ${{matrix.os.runner}}
+    strategy:
+        fail-fast: false
+        matrix:
+           os:
+             - { name: Windows, runner: windows-latest, runtime: win-x64 }
+             - { name: macOS, runner: macos-latest, runtime: osx-x64 }
+             - { name: Linux, runner: ubuntu-latest, runtime: linux-x64 }
+     steps:
+          - name: Checkout
+            uses: actions/checkout@v3
 
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore
+          - name: Setup .NET 6.0 LTS
+            uses: actions/setup-dotnet@v3
+            with:
+                dotnet-version: '6.0.x'
+
+          - name: Build Project
+            run: dotnet build -c Debug -v n ${{ env.PROJECT_NAME }} -r ${{ matrix.os.runtime }} --self-contained
+
+          - name: Test Project
+            run: dotnet test -c Debug ${{ env.PROJECTS_TESTS_NAME }} -r ${{ matrix.os.runtime }} --logger "trx;LogFileName=TestsResults-${{ matrix.os.name }}.trx"
+
+          - name: Upload test artifact
+            if: ${{ always() }}
+            uses: actions/upload-artifact@v2
+            with:
+              name: TestResults-${{ matrix.os.name }}
+              path: ${{ env.TEST_PROJECT_NAME }}/TestResults/*.trx

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,7 +26,7 @@ jobs:
              - { name: Windows, runner: windows-latest, runtime: win-x64 }
              - { name: macOS, runner: macos-latest, runtime: osx-x64 }
              - { name: Linux, runner: ubuntu-latest, runtime: linux-x64 }
-     steps:
+    steps:
           - name: Checkout
             uses: actions/checkout@v3
 
@@ -46,4 +46,4 @@ jobs:
             uses: actions/upload-artifact@v2
             with:
               name: TestResults-${{ matrix.os.name }}
-              path: ${{ env.TEST_PROJECT_NAME }}/TestResults/*.trx
+              path: ${{ env.PROJECTS_TESTS_NAME }}/TestResults/*.trx

--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,6 @@ project.lock.json
 #####
 # End of core ignore list, below put you custom 'per project' settings (patterns or path)
 #####
+
+# TRX results
+TestResults/


### PR DESCRIPTION
Resolves #28.

Adds test coverage for all supported GitHub Actions OS platforms, with detailed reporting provided post-tests.


NB: This requires your testcov project declares itself as a unit test project, and you're using a standard testing framework like XUnit or NUnit