### PR TITLE
Replace Silk.NET

### DIFF
--- a/src/Pie.ShaderCompiler/Compiler.cs
+++ b/src/Pie.ShaderCompiler/Compiler.cs
@@ -1,9 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
-using Silk.NET.Shaderc;
-using Silk.NET.SPIRV;
-using Silk.NET.SPIRV.Cross;
 
 using Spvc = Silk.NET.SPIRV.Cross.Cross;
 using SpvcCompiler = Silk.NET.SPIRV.Cross.Compiler;

--- a/src/Pie.ShaderCompiler/Compiler.cs
+++ b/src/Pie.ShaderCompiler/Compiler.cs
@@ -1,7 +1,9 @@
 ﻿using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
-
+using Silk.NET.Shaderc;
+using Silk.NET.SPIRV;
+using Silk.NET.SPIRV.Cross;
 using Spvc = Silk.NET.SPIRV.Cross.Cross;
 using SpvcCompiler = Silk.NET.SPIRV.Cross.Compiler;
 using SpvcSpecializationConstant = Silk.NET.SPIRV.Cross.SpecializationConstant;

--- a/src/Pie.ShaderCompiler/Pie.ShaderCompiler.csproj
+++ b/src/Pie.ShaderCompiler/Pie.ShaderCompiler.csproj
@@ -26,4 +26,11 @@
         </Content>
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Silk.NET.Shaderc" Version="2.20.0" />
+      <PackageReference Include="Silk.NET.Shaderc.Native" Version="2.20.0" />
+      <PackageReference Include="Silk.NET.SPIRV.Cross" Version="2.20.0" />
+      <PackageReference Include="Silk.NET.SPIRV.Cross.Native" Version="2.20.0" />
+    </ItemGroup>
+
 </Project>

--- a/src/Pie.ShaderCompiler/Pie.ShaderCompiler.csproj
+++ b/src/Pie.ShaderCompiler/Pie.ShaderCompiler.csproj
@@ -14,13 +14,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Silk.NET.Shaderc" Version="2.19.0" />
-      <PackageReference Include="Silk.NET.Shaderc.Native" Version="2.19.0" />
-      <PackageReference Include="Silk.NET.SPIRV.Cross" Version="2.19.0" />
-      <PackageReference Include="Silk.NET.SPIRV.Cross.Native" Version="2.19.0" />
-    </ItemGroup>
-
-    <ItemGroup>
         <Content Include="spirv-cross-c-shared.dll">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <Pack>true</Pack>

--- a/src/Pie.Windowing/Window.cs
+++ b/src/Pie.Windowing/Window.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Text;
-//using Pie.OpenGL;
+using Pie.OpenGL;
 using Pie.Windowing.Events;
 using Pie.SDL;
 
@@ -496,11 +496,11 @@ public sealed unsafe class Window : IDisposable
         {
             case GraphicsApi.OpenGL:
             case GraphicsApi.OpenGLES:
-                /*return GraphicsDevice.CreateOpenGL(new PieGlContext(Sdl.GLGetProcAddress, i =>
+                return GraphicsDevice.CreateOpenGL(new PieGlContext(Sdl.GLGetProcAddress, i =>
                 {
                     Sdl.GLSetSwapInterval(i);
                     Sdl.GLSwapWindow(_window);
-                }), size, _api == GraphicsApi.OpenGLES, options ?? new GraphicsDeviceOptions());*/
+                }), size, _api == GraphicsApi.OpenGLES, options ?? new GraphicsDeviceOptions());
             
             case GraphicsApi.D3D11:
                 SdlSysWmInfo info = new SdlSysWmInfo();

--- a/src/Pie.Windowing/Window.cs
+++ b/src/Pie.Windowing/Window.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Text;
-using Pie.OpenGL;
+//using Pie.OpenGL;
 using Pie.Windowing.Events;
 using Pie.SDL;
 
@@ -496,11 +496,11 @@ public sealed unsafe class Window : IDisposable
         {
             case GraphicsApi.OpenGL:
             case GraphicsApi.OpenGLES:
-                return GraphicsDevice.CreateOpenGL(new PieGlContext(Sdl.GLGetProcAddress, i =>
+                /*return GraphicsDevice.CreateOpenGL(new PieGlContext(Sdl.GLGetProcAddress, i =>
                 {
                     Sdl.GLSetSwapInterval(i);
                     Sdl.GLSwapWindow(_window);
-                }), size, _api == GraphicsApi.OpenGLES, options ?? new GraphicsDeviceOptions());
+                }), size, _api == GraphicsApi.OpenGLES, options ?? new GraphicsDeviceOptions());*/
             
             case GraphicsApi.D3D11:
                 SdlSysWmInfo info = new SdlSysWmInfo();

--- a/src/Pie/Direct3D11/D3D11BlendState.cs
+++ b/src/Pie/Direct3D11/D3D11BlendState.cs
@@ -1,4 +1,5 @@
 using System;
+using Vortice.Direct3D11;
 using static Pie.Direct3D11.DxUtils;
 
 namespace Pie.Direct3D11;
@@ -7,29 +8,29 @@ internal sealed unsafe class D3D11BlendState : BlendState
 {
     public override bool IsDisposed { get; protected set; }
 
-    public ComPtr<ID3D11BlendState> State;
+    public ID3D11BlendState State;
     
-    public D3D11BlendState(ComPtr<ID3D11Device> device, BlendStateDescription description)
+    public D3D11BlendState(ID3D11Device device, BlendStateDescription description)
     {
         Description = description;
 
-        BlendDesc desc = new BlendDesc();
+        BlendDescription desc = new BlendDescription();
         desc.IndependentBlendEnable = false;
         desc.AlphaToCoverageEnable = false;
-        desc.RenderTarget[0] = new RenderTargetBlendDesc()
+        desc.RenderTarget[0] = new RenderTargetBlendDescription()
         {
             BlendEnable = description.Enabled,
-            SrcBlend = GetBlendFromBlendType(description.Source),
-            DestBlend = GetBlendFromBlendType(description.Destination),
-            BlendOp = GetOpFromOp(description.BlendOperation),
-            SrcBlendAlpha = GetBlendFromBlendType(description.SourceAlpha),
-            DestBlendAlpha = GetBlendFromBlendType(description.DestinationAlpha),
-            BlendOpAlpha = GetOpFromOp(description.AlphaBlendOperation),
-            RenderTargetWriteMask = (byte) description.ColorWriteMask
+            SourceBlend = GetBlendFromBlendType(description.Source),
+            DestinationBlend = GetBlendFromBlendType(description.Destination),
+            BlendOperation = GetOpFromOp(description.BlendOperation),
+            SourceBlendAlpha = GetBlendFromBlendType(description.SourceAlpha),
+            DestinationBlendAlpha = GetBlendFromBlendType(description.DestinationAlpha),
+            BlendOperationAlpha = GetOpFromOp(description.AlphaBlendOperation),
+            // TODO: This should be a safe operation, as the two enums are compatible. But it's going to be better to not cast, so that should probably be done at some point.
+            RenderTargetWriteMask = (ColorWriteEnable) description.ColorWriteMask
         };
 
-        if (!Succeeded(device.CreateBlendState(&desc, ref State)))
-            throw new PieException("Failed to create blend state.");
+        State = device.CreateBlendState(desc);
     }
 
     public override BlendStateDescription Description { get; }
@@ -48,27 +49,27 @@ internal sealed unsafe class D3D11BlendState : BlendState
         {
             BlendType.Zero => Blend.Zero,
             BlendType.One => Blend.One,
-            BlendType.SrcColor => Blend.SrcColor,
-            BlendType.OneMinusSrcColor => Blend.InvSrcColor,
-            BlendType.DestColor => Blend.DestColor,
-            BlendType.OneMinusDestColor => Blend.InvDestColor,
-            BlendType.SrcAlpha => Blend.SrcAlpha,
-            BlendType.OneMinusSrcAlpha => Blend.InvSrcAlpha,
-            BlendType.DestAlpha => Blend.DestAlpha,
-            BlendType.OneMinusDestAlpha => Blend.InvDestAlpha,
+            BlendType.SrcColor => Blend.SourceColor,
+            BlendType.OneMinusSrcColor => Blend.InverseSourceColor,
+            BlendType.DestColor => Blend.DestinationColor,
+            BlendType.OneMinusDestColor => Blend.InverseDestinationColor,
+            BlendType.SrcAlpha => Blend.SourceAlpha,
+            BlendType.OneMinusSrcAlpha => Blend.InverseSourceAlpha,
+            BlendType.DestAlpha => Blend.DestinationAlpha,
+            BlendType.OneMinusDestAlpha => Blend.InverseDestinationAlpha,
             _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
         };
     }
 
-    private static BlendOp GetOpFromOp(BlendOperation operation)
+    private static Vortice.Direct3D11.BlendOperation GetOpFromOp(BlendOperation operation)
     {
         return operation switch
         {
-            BlendOperation.Add => BlendOp.Add,
-            BlendOperation.Subtract => BlendOp.Subtract,
-            BlendOperation.ReverseSubtract => BlendOp.RevSubtract,
-            BlendOperation.Min => BlendOp.Min,
-            BlendOperation.Max => BlendOp.Max,
+            BlendOperation.Add => Vortice.Direct3D11.BlendOperation.Add,
+            BlendOperation.Subtract => Vortice.Direct3D11.BlendOperation.Subtract,
+            BlendOperation.ReverseSubtract => Vortice.Direct3D11.BlendOperation.ReverseSubtract,
+            BlendOperation.Min => Vortice.Direct3D11.BlendOperation.Min,
+            BlendOperation.Max => Vortice.Direct3D11.BlendOperation.Max,
             _ => throw new ArgumentOutOfRangeException(nameof(operation), operation, null)
         };
     }

--- a/src/Pie/Direct3D11/D3D11BlendState.cs
+++ b/src/Pie/Direct3D11/D3D11BlendState.cs
@@ -1,6 +1,5 @@
 using System;
 using Vortice.Direct3D11;
-using static Pie.Direct3D11.DxUtils;
 
 namespace Pie.Direct3D11;
 

--- a/src/Pie/Direct3D11/D3D11BlendState.cs
+++ b/src/Pie/Direct3D11/D3D11BlendState.cs
@@ -1,6 +1,4 @@
 using System;
-using Silk.NET.Core.Native;
-using Silk.NET.Direct3D11;
 using static Pie.Direct3D11.DxUtils;
 
 namespace Pie.Direct3D11;

--- a/src/Pie/Direct3D11/D3D11BlendState.cs
+++ b/src/Pie/Direct3D11/D3D11BlendState.cs
@@ -3,7 +3,7 @@ using Vortice.Direct3D11;
 
 namespace Pie.Direct3D11;
 
-internal sealed unsafe class D3D11BlendState : BlendState
+internal sealed class D3D11BlendState : BlendState
 {
     public override bool IsDisposed { get; protected set; }
 

--- a/src/Pie/Direct3D11/D3D11DepthStencilState.cs
+++ b/src/Pie/Direct3D11/D3D11DepthStencilState.cs
@@ -1,17 +1,17 @@
 using System;
-using static Pie.Direct3D11.DxUtils;
+using Vortice.Direct3D11;
 
 namespace Pie.Direct3D11;
 
 internal sealed unsafe class D3D11DepthStencilState : DepthStencilState
 {
-    public ComPtr<ID3D11DepthStencilState> State;
+    public ID3D11DepthStencilState State;
     
-    public D3D11DepthStencilState(ComPtr<ID3D11Device> device, DepthStencilStateDescription description)
+    public D3D11DepthStencilState(ID3D11Device device, DepthStencilStateDescription description)
     {
         Description = description;
 
-        DepthStencilDesc desc = new DepthStencilDesc();
+        DepthStencilDescription desc = new DepthStencilDescription();
         desc.DepthEnable = description.DepthEnabled;
         desc.DepthWriteMask = description.DepthMask ? DepthWriteMask.All : DepthWriteMask.Zero;
         desc.DepthFunc = ComparisonFuncToFunction(description.DepthComparison);
@@ -30,8 +30,7 @@ internal sealed unsafe class D3D11DepthStencilState : DepthStencilState
         desc.BackFace.StencilPassOp = StencilOpToOperation(description.StencilFrontFace.DepthStencilPassOp);
         desc.BackFace.StencilDepthFailOp = StencilOpToOperation(description.StencilFrontFace.DepthFailOp);
 
-        if (!Succeeded(device.CreateDepthStencilState(&desc, ref State)))
-            throw new PieException("Failed to create depth stencil state.");
+        State = device.CreateDepthStencilState(desc);
     }
 
     public override bool IsDisposed { get; protected set; }
@@ -46,34 +45,34 @@ internal sealed unsafe class D3D11DepthStencilState : DepthStencilState
         State.Dispose();
     }
 
-    public Silk.NET.Direct3D11.ComparisonFunc ComparisonFuncToFunction(ComparisonFunc func)
+    public ComparisonFunction ComparisonFuncToFunction(ComparisonFunc func)
     {
         return func switch
         {
-            ComparisonFunc.Never => Silk.NET.Direct3D11.ComparisonFunc.Never,
-            ComparisonFunc.Less => Silk.NET.Direct3D11.ComparisonFunc.Less,
-            ComparisonFunc.Equal => Silk.NET.Direct3D11.ComparisonFunc.Equal,
-            ComparisonFunc.LessEqual => Silk.NET.Direct3D11.ComparisonFunc.LessEqual,
-            ComparisonFunc.Greater => Silk.NET.Direct3D11.ComparisonFunc.Greater,
-            ComparisonFunc.NotEqual => Silk.NET.Direct3D11.ComparisonFunc.NotEqual,
-            ComparisonFunc.GreaterEqual => Silk.NET.Direct3D11.ComparisonFunc.GreaterEqual,
-            ComparisonFunc.Always => Silk.NET.Direct3D11.ComparisonFunc.Always,
+            ComparisonFunc.Never => ComparisonFunction.Never,
+            ComparisonFunc.Less => ComparisonFunction.Less,
+            ComparisonFunc.Equal => ComparisonFunction.Equal,
+            ComparisonFunc.LessEqual => ComparisonFunction.LessEqual,
+            ComparisonFunc.Greater => ComparisonFunction.Greater,
+            ComparisonFunc.NotEqual => ComparisonFunction.NotEqual,
+            ComparisonFunc.GreaterEqual => ComparisonFunction.GreaterEqual,
+            ComparisonFunc.Always => ComparisonFunction.Always,
             _ => throw new ArgumentOutOfRangeException(nameof(func), func, null)
         };
     }
     
-    private Silk.NET.Direct3D11.StencilOp StencilOpToOperation(StencilOp op)
+    private StencilOperation StencilOpToOperation(StencilOp op)
     {
         return op switch
         {
-            StencilOp.Keep => Silk.NET.Direct3D11.StencilOp.Keep,
-            StencilOp.Zero => Silk.NET.Direct3D11.StencilOp.Zero,
-            StencilOp.Replace => Silk.NET.Direct3D11.StencilOp.Replace,
-            StencilOp.Increment => Silk.NET.Direct3D11.StencilOp.IncrSat,
-            StencilOp.IncrementWrap => Silk.NET.Direct3D11.StencilOp.Incr,
-            StencilOp.Decrement => Silk.NET.Direct3D11.StencilOp.DecrSat,
-            StencilOp.DecrementWrap => Silk.NET.Direct3D11.StencilOp.Decr,
-            StencilOp.Invert => Silk.NET.Direct3D11.StencilOp.Invert,
+            StencilOp.Keep => StencilOperation.Keep,
+            StencilOp.Zero => StencilOperation.Zero,
+            StencilOp.Replace => StencilOperation.Replace,
+            StencilOp.Increment => StencilOperation.IncrementSaturate,
+            StencilOp.IncrementWrap => StencilOperation.Increment,
+            StencilOp.Decrement => StencilOperation.DecrementSaturate,
+            StencilOp.DecrementWrap => StencilOperation.Decrement,
+            StencilOp.Invert => StencilOperation.Invert,
             _ => throw new ArgumentOutOfRangeException(nameof(op), op, null)
         };
     }

--- a/src/Pie/Direct3D11/D3D11DepthStencilState.cs
+++ b/src/Pie/Direct3D11/D3D11DepthStencilState.cs
@@ -3,7 +3,7 @@ using Vortice.Direct3D11;
 
 namespace Pie.Direct3D11;
 
-internal sealed unsafe class D3D11DepthStencilState : DepthStencilState
+internal sealed class D3D11DepthStencilState : DepthStencilState
 {
     public ID3D11DepthStencilState State;
     

--- a/src/Pie/Direct3D11/D3D11DepthStencilState.cs
+++ b/src/Pie/Direct3D11/D3D11DepthStencilState.cs
@@ -1,7 +1,4 @@
 using System;
-using Silk.NET.Core.Native;
-using Silk.NET.Direct3D11;
-using static Pie.Direct3D11.D3D11GraphicsDevice;
 using static Pie.Direct3D11.DxUtils;
 
 namespace Pie.Direct3D11;

--- a/src/Pie/Direct3D11/D3D11Framebuffer.cs
+++ b/src/Pie/Direct3D11/D3D11Framebuffer.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Drawing;
-using Silk.NET.Core.Native;
-using Silk.NET.Direct3D11;
-using static Pie.Direct3D11.D3D11GraphicsDevice;
 using static Pie.Direct3D11.DxUtils;
 
 namespace Pie.Direct3D11;

--- a/src/Pie/Direct3D11/D3D11Framebuffer.cs
+++ b/src/Pie/Direct3D11/D3D11Framebuffer.cs
@@ -1,22 +1,23 @@
 ﻿using System.Collections.Generic;
 using System.Drawing;
-using static Pie.Direct3D11.DxUtils;
+using Vortice.Direct3D11;
 
 namespace Pie.Direct3D11;
 
-internal sealed unsafe class D3D11Framebuffer : Framebuffer
+internal sealed class D3D11Framebuffer : Framebuffer
 {
-    public ComPtr<ID3D11RenderTargetView>[] Targets;
-    public ComPtr<ID3D11DepthStencilView> DepthStencil;
+    public ID3D11RenderTargetView[] Targets;
+    public ID3D11DepthStencilView DepthStencil;
 
-    public D3D11Framebuffer(ComPtr<ID3D11Device> device, FramebufferAttachment[] attachments)
+    public D3D11Framebuffer(ID3D11Device device, FramebufferAttachment[] attachments)
     {
         int depthCount = 0;
 
-        List<ComPtr<ID3D11RenderTargetView>> targets = new List<ComPtr<ID3D11RenderTargetView>>();
+        List<ID3D11RenderTargetView> targets = new List<ID3D11RenderTargetView>();
         foreach (FramebufferAttachment attachment in attachments)
         {
-            Silk.NET.DXGI.Format fmt = attachment.Texture.Description.Format.ToDxgiFormat(false);
+            Vortice.DXGI.Format fmt = attachment.Texture.Description.Format.ToDxgiFormat(false);
+            ID3D11Resource texture = ((D3D11Texture) attachment.Texture).Texture;
 
             switch (attachment.Texture.Description.Format)
             {
@@ -27,37 +28,31 @@ internal sealed unsafe class D3D11Framebuffer : Framebuffer
                     if (depthCount > 1)
                         throw new PieException("Framebuffer cannot have more than one depth stencil attachment.");
 
-                    DepthStencilViewDesc depthDesc = new DepthStencilViewDesc()
+                    DepthStencilViewDescription depthDesc = new DepthStencilViewDescription()
                     {
-                        ViewDimension = DsvDimension.Texture2D,
+                        ViewDimension = DepthStencilViewDimension.Texture2D,
                         Format = fmt,
-                        Texture2D = new Tex2DDsv()
+                        Texture2D = new Texture2DDepthStencilView()
                         {
                             MipSlice = 0
                         }
                     };
 
-                    if (!Succeeded(device.CreateDepthStencilView(((D3D11Texture) attachment.Texture).Texture,
-                            &depthDesc, ref DepthStencil)))
-                        throw new PieException("Failed to create depth stencil view.");
+                    device.CreateDepthStencilView(texture, depthDesc);
                     break;
                 default:
-
-                    RenderTargetViewDesc viewDesc = new RenderTargetViewDesc()
+                    RenderTargetViewDescription viewDesc = new RenderTargetViewDescription()
                     {
-                        ViewDimension = RtvDimension.Texture2D,
+                        ViewDimension = RenderTargetViewDimension.Texture2D,
                         Format = fmt,
-                        Texture2D = new Tex2DRtv()
+                        Texture2D = new Texture2DRenderTargetView()
                         {
                             MipSlice = 0
                         }
                     };
 
-                    ComPtr<ID3D11RenderTargetView> targetView = null;
-                    device.CreateRenderTargetView(((D3D11Texture) attachment.Texture).Texture, &viewDesc,
-                        ref targetView);
-
-                    targets.Add(targetView);
+                    ID3D11RenderTargetView view = device.CreateRenderTargetView(texture, viewDesc);
+                    targets.Add(view);
                     break;
             }
         }
@@ -76,10 +71,9 @@ internal sealed unsafe class D3D11Framebuffer : Framebuffer
 
         IsDisposed = true;
         
-        foreach (ComPtr<ID3D11RenderTargetView> view in Targets)
+        foreach (ID3D11RenderTargetView view in Targets)
             view.Dispose();
         
-        if (DepthStencil.Handle != null)
-            DepthStencil.Dispose();
+        DepthStencil?.Dispose();
     }
 }

--- a/src/Pie/Direct3D11/D3D11GraphicsBuffer.cs
+++ b/src/Pie/Direct3D11/D3D11GraphicsBuffer.cs
@@ -5,7 +5,7 @@ using Vortice.Mathematics;
 
 namespace Pie.Direct3D11;
 
-internal sealed unsafe class D3D11GraphicsBuffer : GraphicsBuffer
+internal sealed class D3D11GraphicsBuffer : GraphicsBuffer
 {
     private ID3D11DeviceContext _context;
     private BufferType _type;
@@ -15,7 +15,7 @@ internal sealed unsafe class D3D11GraphicsBuffer : GraphicsBuffer
 
     public ID3D11Buffer Buffer;
 
-    public D3D11GraphicsBuffer(ID3D11Device device, ID3D11DeviceContext context, BufferType type, uint sizeInBytes, void* data, bool dynamic)
+    public unsafe D3D11GraphicsBuffer(ID3D11Device device, ID3D11DeviceContext context, BufferType type, uint sizeInBytes, void* data, bool dynamic)
     {
         _context = context;
         

--- a/src/Pie/Direct3D11/D3D11GraphicsBuffer.cs
+++ b/src/Pie/Direct3D11/D3D11GraphicsBuffer.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
-using Silk.NET.Core.Native;
-using Silk.NET.Direct3D11;
-using static Pie.Direct3D11.D3D11GraphicsDevice;
 using static Pie.Direct3D11.DxUtils;
 
 namespace Pie.Direct3D11;

--- a/src/Pie/Direct3D11/D3D11GraphicsDevice.cs
+++ b/src/Pie/Direct3D11/D3D11GraphicsDevice.cs
@@ -60,9 +60,6 @@ internal sealed unsafe class D3D11GraphicsDevice : GraphicsDevice
             SwapEffect = SwapEffect.FlipDiscard,
             Windowed = true
         };
-        
-        // TODO: Adapter.
-        //Adapter = new GraphicsAdapter(new string(desc.Description));
 
         Result result;
         
@@ -72,6 +69,11 @@ internal sealed unsafe class D3D11GraphicsDevice : GraphicsDevice
             throw new PieException("Failed to create D3D11 device: " + result.Description);
         }
 
+        IDXGIDevice dxgiDevice = _device!.QueryInterface<IDXGIDevice>();
+        IDXGIAdapter adapter = dxgiDevice.GetAdapter();
+
+        Adapter = new GraphicsAdapter(adapter.Description.Description);
+        
         if ((result = _swapChain!.GetBuffer(0, out _colorTexture)).Failure)
             throw new PieException("Failed to get the back color buffer. " + result.Description);
 

--- a/src/Pie/Direct3D11/D3D11GraphicsDevice.cs
+++ b/src/Pie/Direct3D11/D3D11GraphicsDevice.cs
@@ -23,7 +23,6 @@ internal sealed unsafe class D3D11GraphicsDevice : GraphicsDevice
     private ID3D11Device _device;
     private ID3D11DeviceContext _context;
     
-    private IDXGIFactory2 _dxgiFactory;
     private IDXGISwapChain _swapChain;
     private ID3D11Texture2D _colorTexture;
     private ID3D11Texture2D _depthStencilTexture;
@@ -476,7 +475,6 @@ internal sealed unsafe class D3D11GraphicsDevice : GraphicsDevice
         _swapChain.Dispose();
         _device.Dispose();
         _context.Dispose();
-        _dxgiFactory.Dispose();
     }
 
     private void CreateDepthStencilView(Size size)

--- a/src/Pie/Direct3D11/D3D11InputLayout.cs
+++ b/src/Pie/Direct3D11/D3D11InputLayout.cs
@@ -5,7 +5,7 @@ using Vortice.Direct3D11;
 
 namespace Pie.Direct3D11;
 
-internal sealed unsafe class D3D11InputLayout : InputLayout
+internal sealed class D3D11InputLayout : InputLayout
 {
     public readonly ID3D11InputLayout Layout;
 

--- a/src/Pie/Direct3D11/D3D11InputLayout.cs
+++ b/src/Pie/Direct3D11/D3D11InputLayout.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using System.Text;
-using Silk.NET.Core.Native;
-using Silk.NET.Direct3D11;
-using static Pie.Direct3D11.D3D11GraphicsDevice;
 using static Pie.Direct3D11.DxUtils;
 
 namespace Pie.Direct3D11;

--- a/src/Pie/Direct3D11/D3D11InputLayout.cs
+++ b/src/Pie/Direct3D11/D3D11InputLayout.cs
@@ -1,36 +1,33 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using System.Text;
-using static Pie.Direct3D11.DxUtils;
+using Vortice.Direct3D11;
 
 namespace Pie.Direct3D11;
 
 internal sealed unsafe class D3D11InputLayout : InputLayout
 {
-    public readonly ComPtr<ID3D11InputLayout> Layout;
+    public readonly ID3D11InputLayout Layout;
 
-    public D3D11InputLayout(ComPtr<ID3D11Device> device, InputLayoutDescription[] descriptions)
+    public D3D11InputLayout(ID3D11Device device, InputLayoutDescription[] descriptions)
     {
-        GCHandle handle = GCHandle.Alloc(Encoding.UTF8.GetBytes("TEXCOORD"), GCHandleType.Pinned);
-        IntPtr addr = handle.AddrOfPinnedObject();
-        
-        InputElementDesc[] iedesc = new InputElementDesc[descriptions.Length];
+        InputElementDescription[] iedesc = new InputElementDescription[descriptions.Length];
         for (int i = 0; i < iedesc.Length; i++)
         {
-            ref InputElementDesc d = ref iedesc[i];
+            ref InputElementDescription d = ref iedesc[i];
             ref InputLayoutDescription desc = ref descriptions[i];
 
-            Silk.NET.DXGI.Format fmt = desc.Format.ToDxgiFormat(false);
+            Vortice.DXGI.Format fmt = desc.Format.ToDxgiFormat(false);
             
-            d = new InputElementDesc()
+            d = new InputElementDescription()
             {
-                SemanticName = (byte*) addr,
-                SemanticIndex = (uint) i,
-                AlignedByteOffset = desc.Offset,
+                SemanticName = "TEXCOORD",
+                SemanticIndex = i,
+                AlignedByteOffset = (int) desc.Offset,
                 Format = fmt,
-                InputSlot = desc.Slot,
-                InputSlotClass = (InputClassification) desc.InputType,
-                InstanceDataStepRate = (uint) desc.InputType
+                Slot = (int) desc.Slot,
+                Classification = (InputClassification) desc.InputType,
+                InstanceDataStepRate = (int) desc.InputType
             };
         }
 

--- a/src/Pie/Direct3D11/D3D11InputLayout.cs
+++ b/src/Pie/Direct3D11/D3D11InputLayout.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Runtime.InteropServices;
 using System.Text;
+using Vortice.Direct3D;
 using Vortice.Direct3D11;
 
 namespace Pie.Direct3D11;
@@ -33,18 +33,12 @@ internal sealed unsafe class D3D11InputLayout : InputLayout
 
         Descriptions = descriptions;
 
-        ComPtr<ID3D10Blob> dummyBlob = GenerateDummyShader(descriptions);
-        if (!Succeeded(device.CreateInputLayout(in iedesc[0], (uint) iedesc.Length, dummyBlob.GetBufferPointer(),
-                dummyBlob.GetBufferSize(), ref Layout)))
-        {
-            throw new PieException("Failed to create input layout.");
-        }
+        Blob dummyBlob = GenerateDummyShader(descriptions);
+        Layout = device.CreateInputLayout(iedesc, dummyBlob);
         dummyBlob.Dispose();
-        
-        handle.Free();
     }
 
-    private ComPtr<ID3D10Blob> GenerateDummyShader(InputLayoutDescription[] descriptions)
+    private Blob GenerateDummyShader(InputLayoutDescription[] descriptions)
     {
         StringBuilder dummyShader = new StringBuilder();
         dummyShader.AppendLine("struct DummyInput {");

--- a/src/Pie/Direct3D11/D3D11RasterizerState.cs
+++ b/src/Pie/Direct3D11/D3D11RasterizerState.cs
@@ -1,17 +1,17 @@
 ﻿using System;
-using static Pie.Direct3D11.DxUtils;
+using Vortice.Direct3D11;
 
 namespace Pie.Direct3D11;
 
 internal sealed unsafe class D3D11RasterizerState : RasterizerState
 {
-    public ComPtr<ID3D11RasterizerState> State;
+    public ID3D11RasterizerState State;
     
     public override bool IsDisposed { get; protected set; }
 
     public override RasterizerStateDescription Description { get; }
 
-    public D3D11RasterizerState(ComPtr<ID3D11Device> device, RasterizerStateDescription description)
+    public D3D11RasterizerState(ID3D11Device device, RasterizerStateDescription description)
     {
         Description = description;
 
@@ -23,14 +23,14 @@ internal sealed unsafe class D3D11RasterizerState : RasterizerState
             _ => throw new ArgumentOutOfRangeException()
         };
 
-        Silk.NET.Direct3D11.FillMode fm = description.FillMode switch
+        Vortice.Direct3D11.FillMode fm = description.FillMode switch
         {
-            FillMode.Solid => Silk.NET.Direct3D11.FillMode.Solid,
-            FillMode.Wireframe => Silk.NET.Direct3D11.FillMode.Wireframe,
+            FillMode.Solid => Vortice.Direct3D11.FillMode.Solid,
+            FillMode.Wireframe => Vortice.Direct3D11.FillMode.Wireframe,
             _ => throw new ArgumentOutOfRangeException()
         };
 
-        RasterizerDesc desc = new RasterizerDesc()
+        RasterizerDescription desc = new RasterizerDescription()
         {
             CullMode = cullMode,
             FrontCounterClockwise = description.CullDirection == CullDirection.CounterClockwise,
@@ -38,8 +38,7 @@ internal sealed unsafe class D3D11RasterizerState : RasterizerState
             ScissorEnable = description.ScissorTest
         };
 
-        if (!Succeeded(device.CreateRasterizerState(&desc, ref State)))
-            throw new PieException("Failed to create rasterizer state.");
+        State = device.CreateRasterizerState(desc);
     }
 
     public override void Dispose()

--- a/src/Pie/Direct3D11/D3D11RasterizerState.cs
+++ b/src/Pie/Direct3D11/D3D11RasterizerState.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using Silk.NET.Core.Native;
-using Silk.NET.Direct3D11;
-using static Pie.Direct3D11.D3D11GraphicsDevice;
 using static Pie.Direct3D11.DxUtils;
 
 namespace Pie.Direct3D11;

--- a/src/Pie/Direct3D11/D3D11RasterizerState.cs
+++ b/src/Pie/Direct3D11/D3D11RasterizerState.cs
@@ -3,7 +3,7 @@ using Vortice.Direct3D11;
 
 namespace Pie.Direct3D11;
 
-internal sealed unsafe class D3D11RasterizerState : RasterizerState
+internal sealed class D3D11RasterizerState : RasterizerState
 {
     public ID3D11RasterizerState State;
     

--- a/src/Pie/Direct3D11/D3D11SamplerState.cs
+++ b/src/Pie/Direct3D11/D3D11SamplerState.cs
@@ -1,13 +1,14 @@
 using System;
-using static Pie.Direct3D11.DxUtils;
+using Vortice.Direct3D11;
+using Vortice.Mathematics;
 
 namespace Pie.Direct3D11;
 
-internal sealed unsafe class D3D11SamplerState : SamplerState
+internal sealed class D3D11SamplerState : SamplerState
 {
-    public ComPtr<ID3D11SamplerState> State;
+    public ID3D11SamplerState State;
     
-    public D3D11SamplerState(ComPtr<ID3D11Device> device, SamplerStateDescription description)
+    public D3D11SamplerState(ID3D11Device device, SamplerStateDescription description)
     {
         Description = description;
         
@@ -25,26 +26,21 @@ internal sealed unsafe class D3D11SamplerState : SamplerState
             _ => throw new ArgumentOutOfRangeException()
         };
 
-        SamplerDesc desc = new SamplerDesc()
+        SamplerDescription desc = new SamplerDescription()
         {
             Filter = filter,
             AddressU = GetAddressModeFromTextureAddress(description.AddressU),
             AddressV = GetAddressModeFromTextureAddress(description.AddressV),
             AddressW = GetAddressModeFromTextureAddress(description.AddressW),
             MipLODBias = 0,
-            MaxAnisotropy = (uint) description.MaxAnisotropy,
-            ComparisonFunc = Silk.NET.Direct3D11.ComparisonFunc.LessEqual,
+            MaxAnisotropy = description.MaxAnisotropy,
+            ComparisonFunc = Vortice.Direct3D11.ComparisonFunction.LessEqual,
             MinLOD = description.MinLOD,
-            MaxLOD = description.MaxLOD
+            MaxLOD = description.MaxLOD,
+            BorderColor = new Color4(description.BorderColor.R, description.BorderColor.G, description.BorderColor.B, description.BorderColor.A)
         };
 
-        desc.BorderColor[0] = description.BorderColor.R / 255f;
-        desc.BorderColor[1] = description.BorderColor.G / 255f;
-        desc.BorderColor[2] = description.BorderColor.B / 255f;
-        desc.BorderColor[3] = description.BorderColor.A / 255f;
-
-        if (!Succeeded(device.CreateSamplerState(&desc, ref State)))
-            throw new PieException("Failed to create sampler state.");
+        State = device.CreateSamplerState(desc);
     }
     
     public override bool IsDisposed { get; protected set; }

--- a/src/Pie/Direct3D11/D3D11SamplerState.cs
+++ b/src/Pie/Direct3D11/D3D11SamplerState.cs
@@ -1,7 +1,4 @@
 using System;
-using Silk.NET.Core.Native;
-using Silk.NET.Direct3D11;
-using static Pie.Direct3D11.D3D11GraphicsDevice;
 using static Pie.Direct3D11.DxUtils;
 
 namespace Pie.Direct3D11;

--- a/src/Pie/Direct3D11/D3D11Shader.cs
+++ b/src/Pie/Direct3D11/D3D11Shader.cs
@@ -1,14 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using Pie.ShaderCompiler;
 using Vortice.Direct3D;
 using Vortice.Direct3D11;
 
 namespace Pie.Direct3D11;
 
-internal sealed unsafe class D3D11Shader : Shader
+internal sealed class D3D11Shader : Shader
 {
     private ID3D11DeviceContext _context;
     private ShaderObject[] _shaders;

--- a/src/Pie/Direct3D11/D3D11Shader.cs
+++ b/src/Pie/Direct3D11/D3D11Shader.cs
@@ -1,13 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 using Pie.ShaderCompiler;
-using Silk.NET.Core.Native;
-using Silk.NET.Direct3D11;
-using static Pie.Direct3D11.D3D11GraphicsDevice;
 using static Pie.Direct3D11.DxUtils;
 
 namespace Pie.Direct3D11;

--- a/src/Pie/Direct3D11/D3D11Texture.cs
+++ b/src/Pie/Direct3D11/D3D11Texture.cs
@@ -1,20 +1,23 @@
 ﻿using System;
-using static Pie.Direct3D11.DxUtils;
+using Vortice.Direct3D;
+using Vortice.Direct3D11;
+using Vortice.DXGI;
+using Vortice.Mathematics;
 
 namespace Pie.Direct3D11;
 
 internal sealed unsafe class D3D11Texture : Texture
 {
-    private ComPtr<ID3D11DeviceContext> _context;
+    private ID3D11DeviceContext _context;
 
-    public ComPtr<ID3D11Resource> Texture;
-    public ComPtr<ID3D11ShaderResourceView> View;
+    public ID3D11Resource Texture;
+    public ID3D11ShaderResourceView View;
 
     public override bool IsDisposed { get; protected set; }
     
     public override TextureDescription Description { get; set; }
 
-    public D3D11Texture(ComPtr<ID3D11Device> device, ComPtr<ID3D11DeviceContext> context, in TextureDescription description, void* data)
+    public D3D11Texture(ID3D11Device device, ID3D11DeviceContext context, in TextureDescription description, void* data)
     {
         _context = context;
         
@@ -22,30 +25,30 @@ internal sealed unsafe class D3D11Texture : Texture
         
         int pitch = PieUtils.CalculatePitch(description.Format, description.Width, out int bpp);
 
-        Silk.NET.DXGI.Format fmt =
+        Vortice.DXGI.Format fmt =
             description.Format.ToDxgiFormat((description.Usage & TextureUsage.ShaderResource) ==
                                             TextureUsage.ShaderResource);
         
-        BindFlag flags = BindFlag.None;
+        BindFlags flags = BindFlags.None;
         if ((description.Usage & TextureUsage.ShaderResource) == TextureUsage.ShaderResource)
-            flags |= BindFlag.ShaderResource;
+            flags |= BindFlags.ShaderResource;
 
         if (description.Format is Format.D24_UNorm_S8_UInt or Format.D32_Float or Format.D16_UNorm)
-            flags |= BindFlag.DepthStencil;
+            flags |= BindFlags.DepthStencil;
         else if ((description.Usage & TextureUsage.Framebuffer) == TextureUsage.Framebuffer || description.MipLevels == 0)
-            flags |= BindFlag.RenderTarget;
+            flags |= BindFlags.RenderTarget;
 
-        Silk.NET.DXGI.Format svFmt = description.Format.ToDxgiFormat(false);
+        Vortice.DXGI.Format svFmt = description.Format.ToDxgiFormat(false);
 
         svFmt = svFmt switch
         {
-            Silk.NET.DXGI.Format.FormatD32Float => Silk.NET.DXGI.Format.FormatR32Float,
-            Silk.NET.DXGI.Format.FormatD16Unorm => Silk.NET.DXGI.Format.FormatR16Unorm,
-            Silk.NET.DXGI.Format.FormatD24UnormS8Uint => Silk.NET.DXGI.Format.FormatR24UnormX8Typeless,
+            Vortice.DXGI.Format.D32_Float => Vortice.DXGI.Format.R32_Float,
+            Vortice.DXGI.Format.D16_UNorm => Vortice.DXGI.Format.R16_UNorm,
+            Vortice.DXGI.Format.D24_UNorm_S8_UInt => Vortice.DXGI.Format.R24_UNorm_X8_Typeless,
             _ => svFmt
         };
         
-        ShaderResourceViewDesc svDesc = new ShaderResourceViewDesc()
+        ShaderResourceViewDescription svDesc = new ShaderResourceViewDescription()
         {
             Format = svFmt,
         };
@@ -57,118 +60,104 @@ internal sealed unsafe class D3D11Texture : Texture
         switch (description.TextureType)
         {
             case TextureType.Texture1D:
-                Texture1DDesc desc1d = new Texture1DDesc()
+                Texture1DDescription desc1d = new Texture1DDescription()
                 {
-                    Width = (uint) description.Width,
+                    Width = description.Width,
                     Format = fmt,
-                    MipLevels = (uint) mipLevels,
-                    ArraySize = (uint) description.ArraySize,
-                    Usage = Usage.Default,
-                    BindFlags = (uint) flags,
-                    CPUAccessFlags = (uint) CpuAccessFlag.None,
-                    MiscFlags = (uint) (description.MipLevels == 0 ? ResourceMiscFlag.GenerateMips : ResourceMiscFlag.None)
+                    MipLevels = mipLevels,
+                    ArraySize = description.ArraySize,
+                    Usage = ResourceUsage.Default,
+                    BindFlags = flags,
+                    CPUAccessFlags = CpuAccessFlags.None,
+                    MiscFlags = description.MipLevels == 0 ? ResourceOptionFlags.GenerateMips : ResourceOptionFlags.None
                 };
-
-                ComPtr<ID3D11Texture1D> tex1d = null;
-                if (!Succeeded(device.CreateTexture1D(&desc1d, null, ref tex1d)))
-                    throw new PieException("Failed to create 1D texture.");
-                Texture = ComPtr.Downcast<ID3D11Texture1D, ID3D11Resource>(tex1d);
+                
+                Texture = device.CreateTexture1D(desc1d);
 
                 if (description.ArraySize == 1)
                 {
-                    svDesc.ViewDimension = D3DSrvDimension.D3DSrvDimensionTexture1D;
-                    svDesc.Texture1D = new Tex1DSrv()
+                    svDesc.ViewDimension = ShaderResourceViewDimension.Texture1D;
+                    svDesc.Texture1D = new Texture1DShaderResourceView()
                     {
-                        // MipLevels = -1
-                        MipLevels = uint.MaxValue,
+                        MipLevels = -1,
                         MostDetailedMip = 0
                     };
                 }
                 else
                 {
-                    svDesc.ViewDimension = D3DSrvDimension.D3DSrvDimensionTexture1Darray;
-                    svDesc.Texture1DArray = new Tex1DArraySrv()
+                    svDesc.ViewDimension = ShaderResourceViewDimension.Texture1DArray;
+                    svDesc.Texture1DArray = new Texture1DArrayShaderResourceView()
                     {
-                        ArraySize = (uint) description.ArraySize,
+                        ArraySize = description.ArraySize,
                         FirstArraySlice = 0,
-                        // MipLevels = -1
-                        MipLevels = uint.MaxValue,
+                        MipLevels = -1,
                         MostDetailedMip = 0
                     };
                 }
 
                 break;
             case TextureType.Texture2D:
-                Texture2DDesc desc2d = new Texture2DDesc()
+                Texture2DDescription desc2d = new Texture2DDescription()
                 {
-                    Width = (uint) description.Width,
-                    Height = (uint) description.Height,
+                    Width = description.Width,
+                    Height = description.Height,
                     Format = fmt,
-                    MipLevels = (uint) mipLevels,
-                    ArraySize = (uint) description.ArraySize,
-                    SampleDesc = new SampleDesc(1, 0),
+                    MipLevels = mipLevels,
+                    ArraySize = description.ArraySize,
+                    SampleDescription = new SampleDescription(1, 0),
                     //Usage = description.Dynamic ? ResourceUsage.Dynamic : ResourceUsage.Default,
-                    Usage = Usage.Default,
-                    BindFlags = (uint) flags,
-                    CPUAccessFlags = (uint) CpuAccessFlag.None,
-                    MiscFlags = (uint) (description.MipLevels == 0 ? ResourceMiscFlag.GenerateMips : ResourceMiscFlag.None)
+                    Usage = ResourceUsage.Default,
+                    BindFlags = flags,
+                    CPUAccessFlags = CpuAccessFlags.None,
+                    MiscFlags = description.MipLevels == 0 ? ResourceOptionFlags.GenerateMips : ResourceOptionFlags.None
                 };
-
-                ComPtr<ID3D11Texture2D> tex2d = null;
-                if (!Succeeded(device.CreateTexture2D(&desc2d, null, ref tex2d)))
-                    throw new PieException("Failed to create 2D texture.");
-                Texture = ComPtr.Downcast<ID3D11Texture2D, ID3D11Resource>(tex2d);
+                
+                Texture = device.CreateTexture2D(desc2d);
 
                 if (description.ArraySize == 1)
                 {
-                    svDesc.ViewDimension = D3DSrvDimension.D3DSrvDimensionTexture2D;
-                    svDesc.Texture2D = new Tex2DSrv()
+                    svDesc.ViewDimension = ShaderResourceViewDimension.Texture2D;
+                    svDesc.Texture2D = new Texture2DShaderResourceView()
                     {
-                        // MipLevels = -1
-                        MipLevels = uint.MaxValue,
+                        MipLevels = -1,
                         MostDetailedMip = 0
                     };
                 }
                 else
                 {
-                    svDesc.ViewDimension = D3DSrvDimension.D3DSrvDimensionTexture2Darray;
-                    svDesc.Texture2DArray = new Tex2DArraySrv()
-                    {
-                        // MipLevels = -1
-                        MipLevels = uint.MaxValue,
+                    svDesc.ViewDimension = ShaderResourceViewDimension.Texture2DArray;
+                    svDesc.Texture2DArray = new Texture2DArrayShaderResourceView()
+                    { 
+                        MipLevels = -1,
                         MostDetailedMip = 0,
-                        ArraySize = (uint) description.ArraySize,
+                        ArraySize = description.ArraySize,
                         FirstArraySlice = 0
                     };
                 }
                 
                 break;
             case TextureType.Texture3D:
-                Texture3DDesc desc3d = new Texture3DDesc()
+                Texture3DDescription desc3d = new Texture3DDescription()
                 {
-                    Width = (uint) description.Width,
-                    Height = (uint) description.Height,
-                    Depth = (uint) description.Depth,
+                    Width = description.Width,
+                    Height = description.Height,
+                    Depth = description.Depth,
                     Format = fmt,
-                    MipLevels = (uint) mipLevels,
-                    Usage = Usage.Default,
-                    BindFlags = (uint) flags,
-                    CPUAccessFlags = (uint) CpuAccessFlag.None,
-                    MiscFlags = (uint) (description.MipLevels == 0 ? ResourceMiscFlag.GenerateMips : ResourceMiscFlag.None)
+                    MipLevels = mipLevels,
+                    Usage = ResourceUsage.Default,
+                    BindFlags = flags,
+                    CPUAccessFlags = CpuAccessFlags.None,
+                    MiscFlags = description.MipLevels == 0 ? ResourceOptionFlags.GenerateMips : ResourceOptionFlags.None
                 };
-
-                ComPtr<ID3D11Texture3D> tex3d = null;
-                if (!Succeeded(device.CreateTexture3D(&desc3d, null, ref tex3d)))
-                    throw new PieException("Failed to create 3D texture.");
-                Texture = ComPtr.Downcast<ID3D11Texture3D, ID3D11Resource>(tex3d);
+                
+                Texture = device.CreateTexture3D(desc3d);
                 
                 if (description.ArraySize == 1)
                 {
-                    svDesc.ViewDimension = D3DSrvDimension.D3DSrvDimensionTexture3D;
-                    svDesc.Texture3D = new Tex3DSrv()
+                    svDesc.ViewDimension = ShaderResourceViewDimension.Texture3D;
+                    svDesc.Texture3D = new Texture3DShaderResourceView()
                     {
-                        // MipLevels = -1
-                        MipLevels = uint.MaxValue,
+                        MipLevels = -1,
                         MostDetailedMip = 0
                     };
                 }
@@ -176,33 +165,28 @@ internal sealed unsafe class D3D11Texture : Texture
                     throw new NotSupportedException("3D texture arrays are not supported.");
                 break;
             case TextureType.Cubemap:
-                Texture2DDesc desc2dcube = new Texture2DDesc()
+                Texture2DDescription desc2dcube = new Texture2DDescription()
                 {
-                    Width = (uint) description.Width,
-                    Height = (uint) description.Height,
+                    Width = description.Width,
+                    Height = description.Height,
                     Format = fmt,
-                    MipLevels = (uint) mipLevels,
-                    ArraySize = (uint) description.ArraySize * 6, // Multiply by 6 for cubemap
-                    SampleDesc = new SampleDesc(1, 0),
-                    //Usage = description.Dynamic ? ResourceUsage.Dynamic : ResourceUsage.Default,
-                    Usage = Usage.Default,
-                    BindFlags = (uint) flags,
-                    CPUAccessFlags = (uint) CpuAccessFlag.None,
-                    MiscFlags = (uint) (ResourceMiscFlag.Texturecube | (description.MipLevels == 0 ? ResourceMiscFlag.GenerateMips : ResourceMiscFlag.None))
+                    MipLevels = mipLevels,
+                    ArraySize = description.ArraySize * 6, // Multiply by 6 for cubemap
+                    SampleDescription = new SampleDescription(1, 0),
+                    Usage = ResourceUsage.Default,
+                    BindFlags = flags,
+                    CPUAccessFlags = CpuAccessFlags.None,
+                    MiscFlags = ResourceOptionFlags.TextureCube | (description.MipLevels == 0 ? ResourceOptionFlags.GenerateMips : ResourceOptionFlags.None)
                 };
-
-                ComPtr<ID3D11Texture2D> texCube = null;
-                if (!Succeeded(device.CreateTexture2D(&desc2dcube, null, ref texCube)))
-                    throw new PieException("Failed to create Cubemap texture.");
-                Texture = ComPtr.Downcast<ID3D11Texture2D, ID3D11Resource>(texCube);
+                
+                Texture = device.CreateTexture2D(desc2dcube);
 
                 if (description.ArraySize == 1)
                 {
-                    svDesc.ViewDimension = D3DSrvDimension.D3DSrvDimensionTexturecube;
-                    svDesc.TextureCube = new TexcubeSrv()
+                    svDesc.ViewDimension = ShaderResourceViewDimension.TextureCube;
+                    svDesc.TextureCube = new TextureCubeShaderResourceView()
                     {
-                        // MipLevels = -1
-                        MipLevels = uint.MaxValue,
+                        MipLevels = -1,
                         MostDetailedMip = 0
                     };
                 }
@@ -236,8 +220,9 @@ internal sealed unsafe class D3D11Texture : Texture
                     int rowPitch = PieUtils.CalculatePitch(description.Format, width, out _);
                     int depthPitch = PieUtils.CalculatePitch(description.Format, depth, out _);
 
-                    context.UpdateSubresource(Texture, CalcSubresource((uint) i, (uint) a, (uint) mipLevels), null,
-                        (byte*) data + currentOffset, (uint) rowPitch, (uint) depthPitch);
+                    context.UpdateSubresource(Texture,
+                        (int) DxUtils.CalcSubresource((uint) i, (uint) a, (uint) mipLevels), null,
+                        (IntPtr) ((byte*) data + currentOffset), rowPitch, depthPitch);
 
                     currentOffset += currSize;
 
@@ -258,16 +243,15 @@ internal sealed unsafe class D3D11Texture : Texture
 
         if ((description.Usage & TextureUsage.ShaderResource) == TextureUsage.ShaderResource)
         {
-            if (!Succeeded(device.CreateShaderResourceView(Texture, &svDesc, ref View)))
-                throw new PieException("Failed to create shader resource view.");
+            View = device.CreateShaderResourceView(Texture, svDesc);
         }
     }
 
-    public unsafe void Update(int x, int y, int z, int width, int height, int depth, int mipLevel, int arrayIndex, void* data)
+    public void Update(int x, int y, int z, int width, int height, int depth, int mipLevel, int arrayIndex, void* data)
     {
         TextureDescription description = Description;
 
-        uint subresource = CalcSubresource((uint) mipLevel, (uint) arrayIndex,
+        uint subresource = DxUtils.CalcSubresource((uint) mipLevel, (uint) arrayIndex,
             (uint) (description.MipLevels == 0
                 ? PieUtils.CalculateMipLevels(description.Width, description.Height, description.Depth)
                 : description.MipLevels));
@@ -275,10 +259,9 @@ internal sealed unsafe class D3D11Texture : Texture
         int rowPitch = PieUtils.CalculatePitch(description.Format, width, out _);
         int depthPitch = PieUtils.CalculatePitch(description.Format, depth, out _);
 
-        Box box = new Box((uint) x, (uint) y, (uint) z, (uint) (x + width), (uint) (y + height),
-            (uint) (z + depth + 1));
+        Box box = new Box(x, y, z, x + width, y + height, z + depth + 1);
         
-        _context.UpdateSubresource(Texture, subresource, box, data, (uint) rowPitch, (uint) depthPitch);
+        _context.UpdateSubresource(Texture, (int) subresource, box, (IntPtr) data, rowPitch, depthPitch);
     }
 
     public override void Dispose()

--- a/src/Pie/Direct3D11/D3D11Texture.cs
+++ b/src/Pie/Direct3D11/D3D11Texture.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using Silk.NET.Core.Native;
-using Silk.NET.Direct3D11;
-using Silk.NET.DXGI;
-using static Pie.Direct3D11.D3D11GraphicsDevice;
 using static Pie.Direct3D11.DxUtils;
 
 namespace Pie.Direct3D11;

--- a/src/Pie/Direct3D11/DxUtils.cs
+++ b/src/Pie/Direct3D11/DxUtils.cs
@@ -1,87 +1,84 @@
 using System;
 using System.Runtime.CompilerServices;
-using Silk.NET.Core.Native;
-using Silk.NET.Direct3D11;
-using Silk.NET.DXGI;
 
 namespace Pie.Direct3D11;
 
 internal static class DxUtils
 {
-    internal static Silk.NET.DXGI.Format ToDxgiFormat(this Format format, bool shaderResource)
+    internal static Vortice.DXGI.Format ToDxgiFormat(this Format format, bool shaderResource)
     {
         return format switch
         {
-            Format.R8G8B8A8_UNorm => Silk.NET.DXGI.Format.FormatR8G8B8A8Unorm,
-            Format.B8G8R8A8_UNorm => Silk.NET.DXGI.Format.FormatB8G8R8A8Unorm,
-            Format.D24_UNorm_S8_UInt => shaderResource ? Silk.NET.DXGI.Format.FormatR24G8Typeless : Silk.NET.DXGI.Format.FormatD24UnormS8Uint,
-            Format.R8_UNorm => Silk.NET.DXGI.Format.FormatR8Unorm,
-            Format.R8G8_UNorm => Silk.NET.DXGI.Format.FormatR8G8Unorm,
-            Format.R16G16B16A16_Float => Silk.NET.DXGI.Format.FormatR16G16B16A16Float,
-            Format.R32G32B32A32_Float => Silk.NET.DXGI.Format.FormatR32G32B32A32Float,
-            Format.R16G16B16A16_UNorm => Silk.NET.DXGI.Format.FormatR16G16B16A16Unorm,
-            Format.R16G16B16A16_SNorm => Silk.NET.DXGI.Format.FormatR16G16B16A16SNorm,
-            Format.R16G16B16A16_SInt => Silk.NET.DXGI.Format.FormatR16G16B16A16Sint,
-            Format.R16G16B16A16_UInt => Silk.NET.DXGI.Format.FormatR16G16B16A16Uint,
-            Format.R32G32_SInt => Silk.NET.DXGI.Format.FormatR32G32Sint,
-            Format.R32G32_UInt => Silk.NET.DXGI.Format.FormatR32G32Uint,
-            Format.R32G32_Float => Silk.NET.DXGI.Format.FormatR32G32Float,
-            Format.R32G32B32_SInt => Silk.NET.DXGI.Format.FormatR32G32B32Sint,
-            Format.R32G32B32_UInt => Silk.NET.DXGI.Format.FormatR32G32B32Uint,
-            Format.R32G32B32_Float => Silk.NET.DXGI.Format.FormatR32G32B32Float,
-            Format.R32G32B32A32_SInt => Silk.NET.DXGI.Format.FormatR32G32B32A32Sint,
-            Format.R32G32B32A32_UInt => Silk.NET.DXGI.Format.FormatR32G32B32A32Uint,
-            Format.R8_SNorm => Silk.NET.DXGI.Format.FormatR8SNorm,
-            Format.R8_SInt => Silk.NET.DXGI.Format.FormatR8Sint,
-            Format.R8_UInt => Silk.NET.DXGI.Format.FormatR8Uint,
-            Format.R8G8_SNorm => Silk.NET.DXGI.Format.FormatR8G8SNorm,
-            Format.R8G8_SInt => Silk.NET.DXGI.Format.FormatR8G8Sint,
-            Format.R8G8_UInt => Silk.NET.DXGI.Format.FormatR8G8Uint,
-            Format.R8G8B8A8_SNorm => Silk.NET.DXGI.Format.FormatR8G8B8A8SNorm,
-            Format.R8G8B8A8_SInt => Silk.NET.DXGI.Format.FormatR8G8B8A8Sint,
-            Format.R8G8B8A8_UInt => Silk.NET.DXGI.Format.FormatR8G8B8A8Uint,
-            Format.R16_UNorm => Silk.NET.DXGI.Format.FormatR16Unorm,
-            Format.R16_SNorm => Silk.NET.DXGI.Format.FormatR16SNorm,
-            Format.R16_SInt => Silk.NET.DXGI.Format.FormatR16Sint,
-            Format.R16_UInt => Silk.NET.DXGI.Format.FormatR16Uint,
-            Format.R16_Float => Silk.NET.DXGI.Format.FormatR16Float,
-            Format.R16G16_UNorm => Silk.NET.DXGI.Format.FormatR16G16Unorm,
-            Format.R16G16_SNorm => Silk.NET.DXGI.Format.FormatR16G16SNorm,
-            Format.R16G16_SInt => Silk.NET.DXGI.Format.FormatR16G16Sint,
-            Format.R16G16_UInt => Silk.NET.DXGI.Format.FormatR16G16Uint,
-            Format.R16G16_Float => Silk.NET.DXGI.Format.FormatR16G16Float,
-            Format.R32_SInt => Silk.NET.DXGI.Format.FormatR32Sint,
-            Format.R32_UInt => Silk.NET.DXGI.Format.FormatR32Uint,
-            Format.R32_Float => Silk.NET.DXGI.Format.FormatR32Float,
-            Format.R8G8B8A8_UNorm_SRgb => Silk.NET.DXGI.Format.FormatR8G8B8A8UnormSrgb,
-            Format.B8G8R8A8_UNorm_SRgb => Silk.NET.DXGI.Format.FormatB8G8R8A8UnormSrgb,
-            Format.D32_Float => shaderResource ? Silk.NET.DXGI.Format.FormatR32Typeless : Silk.NET.DXGI.Format.FormatD32Float,
-            Format.D16_UNorm => shaderResource ? Silk.NET.DXGI.Format.FormatR16Typeless : Silk.NET.DXGI.Format.FormatD16Unorm,
-            Format.BC1_UNorm => Silk.NET.DXGI.Format.FormatBC1Unorm,
-            Format.BC1_UNorm_SRgb => Silk.NET.DXGI.Format.FormatBC1UnormSrgb,
-            Format.BC2_UNorm => Silk.NET.DXGI.Format.FormatBC2Unorm,
-            Format.BC2_UNorm_SRgb => Silk.NET.DXGI.Format.FormatBC2UnormSrgb,
-            Format.BC3_UNorm => Silk.NET.DXGI.Format.FormatBC3Unorm,
-            Format.BC3_UNorm_SRgb => Silk.NET.DXGI.Format.FormatBC3UnormSrgb,
-            Format.BC4_UNorm => Silk.NET.DXGI.Format.FormatBC4Unorm,
-            Format.BC4_SNorm => Silk.NET.DXGI.Format.FormatBC4SNorm,
-            Format.BC5_UNorm => Silk.NET.DXGI.Format.FormatBC5Unorm,
-            Format.BC5_SNorm => Silk.NET.DXGI.Format.FormatBC5SNorm,
-            Format.BC6H_UF16 => Silk.NET.DXGI.Format.FormatBC6HUF16,
-            Format.BC6H_SF16 => Silk.NET.DXGI.Format.FormatBC6HSF16,
-            Format.BC7_UNorm => Silk.NET.DXGI.Format.FormatBC7Unorm,
-            Format.BC7_UNorm_SRgb => Silk.NET.DXGI.Format.FormatBC7UnormSrgb,
+            Format.R8G8B8A8_UNorm => Vortice.DXGI.Format.R8G8B8A8_UNorm,
+            Format.B8G8R8A8_UNorm => Vortice.DXGI.Format.B8G8R8A8_UNorm,
+            Format.D24_UNorm_S8_UInt => shaderResource ? Vortice.DXGI.Format.R24G8_Typeless : Vortice.DXGI.Format.D24_UNorm_S8_UInt,
+            Format.R8_UNorm => Vortice.DXGI.Format.R8_UNorm,
+            Format.R8G8_UNorm => Vortice.DXGI.Format.R8G8_UNorm,
+            Format.R16G16B16A16_Float => Vortice.DXGI.Format.R16G16B16A16_Float,
+            Format.R32G32B32A32_Float => Vortice.DXGI.Format.R32G32B32A32_Float,
+            Format.R16G16B16A16_UNorm => Vortice.DXGI.Format.R16G16B16A16_UNorm,
+            Format.R16G16B16A16_SNorm => Vortice.DXGI.Format.R16G16B16A16_SNorm,
+            Format.R16G16B16A16_SInt => Vortice.DXGI.Format.R16G16B16A16_SInt,
+            Format.R16G16B16A16_UInt => Vortice.DXGI.Format.R16G16B16A16_UInt,
+            Format.R32G32_SInt => Vortice.DXGI.Format.R32G32_SInt,
+            Format.R32G32_UInt => Vortice.DXGI.Format.R32G32_UInt,
+            Format.R32G32_Float => Vortice.DXGI.Format.R32G32_Float,
+            Format.R32G32B32_SInt => Vortice.DXGI.Format.R32G32B32_SInt,
+            Format.R32G32B32_UInt => Vortice.DXGI.Format.R32G32B32_UInt,
+            Format.R32G32B32_Float => Vortice.DXGI.Format.R32G32B32_Float,
+            Format.R32G32B32A32_SInt => Vortice.DXGI.Format.R32G32B32A32_SInt,
+            Format.R32G32B32A32_UInt => Vortice.DXGI.Format.R32G32B32A32_UInt,
+            Format.R8_SNorm => Vortice.DXGI.Format.R8_SNorm,
+            Format.R8_SInt => Vortice.DXGI.Format.R8_SInt,
+            Format.R8_UInt => Vortice.DXGI.Format.R8_UInt,
+            Format.R8G8_SNorm => Vortice.DXGI.Format.R8G8_SNorm,
+            Format.R8G8_SInt => Vortice.DXGI.Format.R8G8_SInt,
+            Format.R8G8_UInt => Vortice.DXGI.Format.R8G8_UInt,
+            Format.R8G8B8A8_SNorm => Vortice.DXGI.Format.R8G8B8A8_SNorm,
+            Format.R8G8B8A8_SInt => Vortice.DXGI.Format.R8G8B8A8_SInt,
+            Format.R8G8B8A8_UInt => Vortice.DXGI.Format.R8G8B8A8_UInt,
+            Format.R16_UNorm => Vortice.DXGI.Format.R16_UNorm,
+            Format.R16_SNorm => Vortice.DXGI.Format.R16_SNorm,
+            Format.R16_SInt => Vortice.DXGI.Format.R16_SInt,
+            Format.R16_UInt => Vortice.DXGI.Format.R16_UInt,
+            Format.R16_Float => Vortice.DXGI.Format.R16_Float,
+            Format.R16G16_UNorm => Vortice.DXGI.Format.R16G16_UNorm,
+            Format.R16G16_SNorm => Vortice.DXGI.Format.R16G16_SNorm,
+            Format.R16G16_SInt => Vortice.DXGI.Format.R16G16_SInt,
+            Format.R16G16_UInt => Vortice.DXGI.Format.R16G16_UInt,
+            Format.R16G16_Float => Vortice.DXGI.Format.R16G16_Float,
+            Format.R32_SInt => Vortice.DXGI.Format.R32_SInt,
+            Format.R32_UInt => Vortice.DXGI.Format.R32_UInt,
+            Format.R32_Float => Vortice.DXGI.Format.R32_Float,
+            Format.R8G8B8A8_UNorm_SRgb => Vortice.DXGI.Format.R8G8B8A8_UNorm_SRgb,
+            Format.B8G8R8A8_UNorm_SRgb => Vortice.DXGI.Format.B8G8R8A8_UNorm_SRgb,
+            Format.D32_Float => shaderResource ? Vortice.DXGI.Format.R32_Typeless : Vortice.DXGI.Format.D32_Float,
+            Format.D16_UNorm => shaderResource ? Vortice.DXGI.Format.R16_Typeless : Vortice.DXGI.Format.D16_UNorm,
+            Format.BC1_UNorm => Vortice.DXGI.Format.BC1_UNorm,
+            Format.BC1_UNorm_SRgb => Vortice.DXGI.Format.BC1_UNorm_SRgb,
+            Format.BC2_UNorm => Vortice.DXGI.Format.BC2_UNorm,
+            Format.BC2_UNorm_SRgb => Vortice.DXGI.Format.BC2_UNorm_SRgb,
+            Format.BC3_UNorm => Vortice.DXGI.Format.BC3_UNorm,
+            Format.BC3_UNorm_SRgb => Vortice.DXGI.Format.BC3_UNorm_SRgb,
+            Format.BC4_UNorm => Vortice.DXGI.Format.BC4_UNorm,
+            Format.BC4_SNorm => Vortice.DXGI.Format.BC4_SNorm,
+            Format.BC5_UNorm => Vortice.DXGI.Format.BC5_UNorm,
+            Format.BC5_SNorm => Vortice.DXGI.Format.BC5_SNorm,
+            Format.BC6H_UF16 => Vortice.DXGI.Format.BC6H_Uf16,
+            Format.BC6H_SF16 => Vortice.DXGI.Format.BC6H_Uf16,
+            Format.BC7_UNorm => Vortice.DXGI.Format.BC7_UNorm,
+            Format.BC7_UNorm_SRgb => Vortice.DXGI.Format.BC7_UNorm_SRgb,
             _ => throw new ArgumentOutOfRangeException(nameof(format), format, null)
         };
     }
 
-    internal static Map ToDx11MapMode(this MapMode mode)
+    internal static Vortice.Direct3D11.MapMode ToDx11MapMode(this MapMode mode)
     {
         return mode switch
         {
-            MapMode.Read => Map.Read,
-            MapMode.Write => Map.WriteDiscard,
-            MapMode.ReadWrite => Map.ReadWrite,
+            MapMode.Read => Vortice.Direct3D11.MapMode.Read,
+            MapMode.Write => Vortice.Direct3D11.MapMode.WriteDiscard,
+            MapMode.ReadWrite => Vortice.Direct3D11.MapMode.ReadWrite,
             _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
         };
     }
@@ -89,28 +86,4 @@ internal static class DxUtils
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static uint CalcSubresource(uint mipSlice, uint arraySlice, uint mipLevels) =>
         mipSlice + (arraySlice * mipLevels);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static bool Succeeded(int result, out HResult hresult)
-    {
-        hresult = (HResult) result;
-        if (!hresult.IsSuccess)
-        {
-            Console.WriteLine("HRESULT code: " + hresult.Code);
-            return false;
-        }
-        return true;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static bool Succeeded(int result) => Succeeded(result, out _);
-
-    internal static unsafe bool CheckDebugSdk(D3D11 d3d11)
-    {
-        if (!Succeeded(d3d11.CreateDevice(new ComPtr<IDXGIAdapter>((IDXGIAdapter*) null), D3DDriverType.Hardware, 0,
-                (uint) CreateDeviceFlag.Debug, null, 0, D3D11.SdkVersion, null, null, null)))
-            return false;
-
-        return true;
-    }
 }

--- a/src/Pie/GraphicsDevice.cs
+++ b/src/Pie/GraphicsDevice.cs
@@ -4,7 +4,7 @@ using System.Numerics;
 using Pie.DebugLayer;
 using Pie.Direct3D11;
 using Pie.Null;
-using Pie.OpenGL;
+//using Pie.OpenGL;
 using Pie.ShaderCompiler;
 
 namespace Pie;
@@ -462,7 +462,7 @@ public abstract class GraphicsDevice : IDisposable
     /// </summary>
     public abstract void Dispose();
 
-    /// <summary>
+    /*/// <summary>
     /// Create an OpenGL 3.3 graphics device.
     /// </summary>
     /// <param name="context">The GL context.</param>
@@ -478,7 +478,7 @@ public abstract class GraphicsDevice : IDisposable
             return new DebugGraphicsDevice(device);
         
         return device;
-    }
+    }*/
 
     /// <summary>
     /// Create a Direct3D 11 graphics device.

--- a/src/Pie/GraphicsDevice.cs
+++ b/src/Pie/GraphicsDevice.cs
@@ -4,7 +4,7 @@ using System.Numerics;
 using Pie.DebugLayer;
 using Pie.Direct3D11;
 using Pie.Null;
-//using Pie.OpenGL;
+using Pie.OpenGL;
 using Pie.ShaderCompiler;
 
 namespace Pie;
@@ -462,7 +462,7 @@ public abstract class GraphicsDevice : IDisposable
     /// </summary>
     public abstract void Dispose();
 
-    /*/// <summary>
+    /// <summary>
     /// Create an OpenGL 3.3 graphics device.
     /// </summary>
     /// <param name="context">The GL context.</param>
@@ -478,7 +478,7 @@ public abstract class GraphicsDevice : IDisposable
             return new DebugGraphicsDevice(device);
         
         return device;
-    }*/
+    }
 
     /// <summary>
     /// Create a Direct3D 11 graphics device.

--- a/src/Pie/OpenGL/GlBlendState.cs
+++ b/src/Pie/OpenGL/GlBlendState.cs
@@ -81,15 +81,15 @@ internal sealed class GlBlendState : BlendState
         };
     }
 
-    private static BlendEquationModeEXT GetEquationFromOp(BlendOperation operation)
+    private static BlendEquationMode GetEquationFromOp(BlendOperation operation)
     {
         return operation switch
         {
-            BlendOperation.Add => BlendEquationModeEXT.FuncAdd,
-            BlendOperation.Subtract => BlendEquationModeEXT.FuncSubtract,
-            BlendOperation.ReverseSubtract => BlendEquationModeEXT.FuncReverseSubtract,
-            BlendOperation.Min => BlendEquationModeEXT.Min,
-            BlendOperation.Max => BlendEquationModeEXT.Max,
+            BlendOperation.Add => BlendEquationMode.FuncAdd,
+            BlendOperation.Subtract => BlendEquationMode.FuncSubtract,
+            BlendOperation.ReverseSubtract => BlendEquationMode.FuncReverseSubtract,
+            BlendOperation.Min => BlendEquationMode.Min,
+            BlendOperation.Max => BlendEquationMode.Max,
             _ => throw new ArgumentOutOfRangeException(nameof(operation), operation, null)
         };
     }

--- a/src/Pie/OpenGL/GlBlendState.cs
+++ b/src/Pie/OpenGL/GlBlendState.cs
@@ -1,6 +1,5 @@
 using System;
 using OpenTK.Graphics.OpenGL4;
-using static Pie.OpenGL.GlGraphicsDevice;
 
 namespace Pie.OpenGL;
 
@@ -8,10 +7,10 @@ internal sealed class GlBlendState : BlendState
 {
     private BlendStateDescription _description;
     
-    private BlendingFactor _src;
-    private BlendingFactor _dst;
-    private BlendingFactor _srcAlpha;
-    private BlendingFactor _dstAlpha;
+    private BlendingFactorSrc _src;
+    private BlendingFactorDest _dst;
+    private BlendingFactorSrc _srcAlpha;
+    private BlendingFactorDest _dstAlpha;
     private BlendEquationMode _rgbEq;
     private BlendEquationMode _alphaEq;
 
@@ -21,11 +20,11 @@ internal sealed class GlBlendState : BlendState
     {
         _description = description;
         
-        _src = GetBlendingFactorFromBlendType(description.Source);
-        _dst = GetBlendingFactorFromBlendType(description.Destination);
+        _src = (BlendingFactorSrc) GetBlendingFactorFromBlendType(description.Source);
+        _dst = (BlendingFactorDest) GetBlendingFactorFromBlendType(description.Destination);
 
-        _srcAlpha = GetBlendingFactorFromBlendType(description.SourceAlpha);
-        _dstAlpha = GetBlendingFactorFromBlendType(description.DestinationAlpha);
+        _srcAlpha = (BlendingFactorSrc) GetBlendingFactorFromBlendType(description.SourceAlpha);
+        _dstAlpha = (BlendingFactorDest) GetBlendingFactorFromBlendType(description.DestinationAlpha);
 
         _rgbEq = GetEquationFromOp(description.BlendOperation);
         _alphaEq = GetEquationFromOp(description.AlphaBlendOperation);
@@ -42,17 +41,17 @@ internal sealed class GlBlendState : BlendState
 
     public void Set()
     {
-        Gl.ColorMask(_red, _green, _blue, _alpha);
+        GL.ColorMask(_red, _green, _blue, _alpha);
         
         if (!_description.Enabled)
         {
-            Gl.Disable(EnableCap.Blend);
+            GL.Disable(EnableCap.Blend);
             return;
         }
         
-        Gl.Enable(EnableCap.Blend);
-        Gl.BlendFuncSeparate(_src, _dst, _srcAlpha, _dstAlpha);
-        Gl.BlendEquationSeparate(_rgbEq, _alphaEq);
+        GL.Enable(EnableCap.Blend);
+        GL.BlendFuncSeparate(_src, _dst, _srcAlpha, _dstAlpha);
+        GL.BlendEquationSeparate(_rgbEq, _alphaEq);
     }
     
     public override void Dispose()

--- a/src/Pie/OpenGL/GlBlendState.cs
+++ b/src/Pie/OpenGL/GlBlendState.cs
@@ -1,5 +1,4 @@
 using System;
-using Silk.NET.OpenGL;
 using static Pie.OpenGL.GlGraphicsDevice;
 
 namespace Pie.OpenGL;

--- a/src/Pie/OpenGL/GlBlendState.cs
+++ b/src/Pie/OpenGL/GlBlendState.cs
@@ -1,4 +1,5 @@
 using System;
+using OpenTK.Graphics.OpenGL4;
 using static Pie.OpenGL.GlGraphicsDevice;
 
 namespace Pie.OpenGL;
@@ -11,8 +12,8 @@ internal sealed class GlBlendState : BlendState
     private BlendingFactor _dst;
     private BlendingFactor _srcAlpha;
     private BlendingFactor _dstAlpha;
-    private BlendEquationModeEXT _rgbEq;
-    private BlendEquationModeEXT _alphaEq;
+    private BlendEquationMode _rgbEq;
+    private BlendEquationMode _alphaEq;
 
     private bool _red, _green, _blue, _alpha;
     

--- a/src/Pie/OpenGL/GlDepthStencilState.cs
+++ b/src/Pie/OpenGL/GlDepthStencilState.cs
@@ -1,5 +1,5 @@
 using System;
-using static Pie.OpenGL.GlGraphicsDevice;
+using OpenTK.Graphics.OpenGL4;
 
 namespace Pie.OpenGL;
 
@@ -8,14 +8,14 @@ internal sealed class GlDepthStencilState : DepthStencilState
     private DepthStencilStateDescription _description;
     private DepthFunction _depthFunction;
 
-    private Silk.NET.OpenGL.StencilOp _frontStencilPass;
-    private Silk.NET.OpenGL.StencilOp _frontStencilFail;
-    private Silk.NET.OpenGL.StencilOp _frontDepthFail;
+    private OpenTK.Graphics.OpenGL4.StencilOp _frontStencilPass;
+    private OpenTK.Graphics.OpenGL4.StencilOp _frontStencilFail;
+    private OpenTK.Graphics.OpenGL4.StencilOp _frontDepthFail;
     private StencilFunction _frontFunc;
     
-    private Silk.NET.OpenGL.StencilOp _backStencilPass;
-    private Silk.NET.OpenGL.StencilOp _backStencilFail;
-    private Silk.NET.OpenGL.StencilOp _backDepthFail;
+    private OpenTK.Graphics.OpenGL4.StencilOp _backStencilPass;
+    private OpenTK.Graphics.OpenGL4.StencilOp _backStencilFail;
+    private OpenTK.Graphics.OpenGL4.StencilOp _backDepthFail;
     private StencilFunction _backFunc;
 
     public GlDepthStencilState(DepthStencilStateDescription description)
@@ -39,24 +39,24 @@ internal sealed class GlDepthStencilState : DepthStencilState
     {
         if (_description.DepthEnabled)
         {
-            Gl.Enable(EnableCap.DepthTest);
-            Gl.DepthMask(_description.DepthMask);
-            Gl.DepthFunc(_depthFunction);
+            GL.Enable(EnableCap.DepthTest);
+            GL.DepthMask(_description.DepthMask);
+            GL.DepthFunc(_depthFunction);
         }
         else
-            Gl.Disable(EnableCap.DepthTest);
+            GL.Disable(EnableCap.DepthTest);
 
         if (_description.StencilEnabled)
         {
-            Gl.Enable(EnableCap.StencilTest);
-            Gl.StencilOpSeparate(TriangleFace.Front, _frontStencilFail, _frontDepthFail, _frontStencilPass);
-            Gl.StencilOpSeparate(TriangleFace.Back, _backStencilFail, _backDepthFail, _backStencilPass);
-            Gl.StencilMask(_description.StencilWriteMask);
-            Gl.StencilFuncSeparate(TriangleFace.Front, _frontFunc, stencilRef, _description.StencilReadMask);
-            Gl.StencilFuncSeparate(TriangleFace.Back, _backFunc, stencilRef, _description.StencilReadMask);
+            GL.Enable(EnableCap.StencilTest);
+            GL.StencilOpSeparate(OpenTK.Graphics.OpenGL4.StencilFace.Front, _frontStencilFail, _frontDepthFail, _frontStencilPass);
+            GL.StencilOpSeparate(OpenTK.Graphics.OpenGL4.StencilFace.Back, _backStencilFail, _backDepthFail, _backStencilPass);
+            GL.StencilMask(_description.StencilWriteMask);
+            GL.StencilFuncSeparate(OpenTK.Graphics.OpenGL4.StencilFace.Front, _frontFunc, stencilRef, _description.StencilReadMask);
+            GL.StencilFuncSeparate(OpenTK.Graphics.OpenGL4.StencilFace.Back, _backFunc, stencilRef, _description.StencilReadMask);
         }
         else
-            Gl.Disable(EnableCap.StencilTest);
+            GL.Disable(EnableCap.StencilTest);
     }
 
     public override bool IsDisposed { get; protected set; }
@@ -69,34 +69,35 @@ internal sealed class GlDepthStencilState : DepthStencilState
         // There is nothing to dispose.
     }
 
-    private Silk.NET.OpenGL.StencilOp StencilOpToOp(StencilOp op)
+    private OpenTK.Graphics.OpenGL4.StencilOp StencilOpToOp(StencilOp op)
     {
         return op switch
         {
-            StencilOp.Keep => Silk.NET.OpenGL.StencilOp.Keep,
-            StencilOp.Zero => Silk.NET.OpenGL.StencilOp.Zero,
-            StencilOp.Replace => Silk.NET.OpenGL.StencilOp.Replace,
-            StencilOp.Increment => Silk.NET.OpenGL.StencilOp.Incr,
-            StencilOp.IncrementWrap => Silk.NET.OpenGL.StencilOp.IncrWrap,
-            StencilOp.Decrement => Silk.NET.OpenGL.StencilOp.Decr,
-            StencilOp.DecrementWrap => Silk.NET.OpenGL.StencilOp.DecrWrap,
-            StencilOp.Invert => Silk.NET.OpenGL.StencilOp.Invert,
+            StencilOp.Keep => OpenTK.Graphics.OpenGL4.StencilOp.Keep,
+            StencilOp.Zero => OpenTK.Graphics.OpenGL4.StencilOp.Zero,
+            StencilOp.Replace => OpenTK.Graphics.OpenGL4.StencilOp.Replace,
+            StencilOp.Increment => OpenTK.Graphics.OpenGL4.StencilOp.Incr,
+            StencilOp.IncrementWrap => OpenTK.Graphics.OpenGL4.StencilOp.IncrWrap,
+            StencilOp.Decrement => OpenTK.Graphics.OpenGL4.StencilOp.Decr,
+            StencilOp.DecrementWrap => OpenTK.Graphics.OpenGL4.StencilOp.DecrWrap,
+            StencilOp.Invert => OpenTK.Graphics.OpenGL4.StencilOp.Invert,
             _ => throw new ArgumentOutOfRangeException(nameof(op), op, null)
         };
     }
 
-    private GLEnum FuncToEnum(ComparisonFunc func)
+    private OpenTK.Graphics.OpenGL4.All FuncToEnum(ComparisonFunc func)
     {
         return func switch
         {
-            ComparisonFunc.Never => GLEnum.Never,
-            ComparisonFunc.Less => GLEnum.Less,
-            ComparisonFunc.Equal => GLEnum.Equal,
-            ComparisonFunc.LessEqual => GLEnum.Lequal,
-            ComparisonFunc.Greater => GLEnum.Greater,
-            ComparisonFunc.NotEqual => GLEnum.Notequal,
-            ComparisonFunc.GreaterEqual => GLEnum.Gequal,
-            ComparisonFunc.Always => GLEnum.Always,
+            ComparisonFunc.Never => All.Never,
+            ComparisonFunc.Less => All.Less,
+            ComparisonFunc.Equal => All.Equal,
+            ComparisonFunc.LessEqual => All.Lequal,
+            ComparisonFunc.Greater => All.Greater,
+            ComparisonFunc.NotEqual => All.Notequal,
+            ComparisonFunc.GreaterEqual => All.Gequal,
+            ComparisonFunc.Always => All.Always,
+            _ => throw new ArgumentOutOfRangeException(nameof(func), func, null)
         };
     }
 }

--- a/src/Pie/OpenGL/GlDepthStencilState.cs
+++ b/src/Pie/OpenGL/GlDepthStencilState.cs
@@ -1,5 +1,4 @@
 using System;
-using Silk.NET.OpenGL;
 using static Pie.OpenGL.GlGraphicsDevice;
 
 namespace Pie.OpenGL;

--- a/src/Pie/OpenGL/GlFramebuffer.cs
+++ b/src/Pie/OpenGL/GlFramebuffer.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Drawing;
-using Silk.NET.OpenGL;
 using static Pie.OpenGL.GlGraphicsDevice;
 
 namespace Pie.OpenGL;

--- a/src/Pie/OpenGL/GlFramebuffer.cs
+++ b/src/Pie/OpenGL/GlFramebuffer.cs
@@ -1,36 +1,37 @@
 ﻿using System.Collections.Generic;
 using System.Drawing;
-using static Pie.OpenGL.GlGraphicsDevice;
+using System.Runtime.CompilerServices;
+using OpenTK.Graphics.OpenGL4;
 
 namespace Pie.OpenGL;
 
 internal class GlFramebuffer : Framebuffer
 {
-    public uint Handle;
+    public int Handle;
 
     // TODO: More options in FramebufferAttachment for both GL and D3D11.
     public unsafe GlFramebuffer(FramebufferAttachment[] attachments)
     {
-        Handle = Gl.GenFramebuffer();
-        Gl.BindFramebuffer(FramebufferTarget.Framebuffer, Handle);
+        Handle = GL.GenFramebuffer();
+        GL.BindFramebuffer(FramebufferTarget.Framebuffer, Handle);
 
         int colorNum = 0;
-        List<GLEnum> colAttachments = new List<GLEnum>();
+        List<OpenTK.Graphics.OpenGL4.FramebufferAttachment> colAttachments = new List<OpenTK.Graphics.OpenGL4.FramebufferAttachment>();
         foreach (FramebufferAttachment attachment in attachments)
         {
-            Silk.NET.OpenGL.FramebufferAttachment glAttachment;
+            OpenTK.Graphics.OpenGL4.FramebufferAttachment glAttachment;
             switch (attachment.Texture.Description.Format)
             {
                 case Format.D32_Float:
                 case Format.D16_UNorm:
-                    glAttachment = Silk.NET.OpenGL.FramebufferAttachment.DepthAttachment;
+                    glAttachment = OpenTK.Graphics.OpenGL4.FramebufferAttachment.DepthAttachment;
                     break;
                 case Format.D24_UNorm_S8_UInt:
-                    glAttachment = Silk.NET.OpenGL.FramebufferAttachment.DepthStencilAttachment;
+                    glAttachment = OpenTK.Graphics.OpenGL4.FramebufferAttachment.DepthStencilAttachment;
                     break;
                 default:
-                    glAttachment = Silk.NET.OpenGL.FramebufferAttachment.ColorAttachment0 + colorNum;
-                    colAttachments.Add((GLEnum) glAttachment);
+                    glAttachment = OpenTK.Graphics.OpenGL4.FramebufferAttachment.ColorAttachment0 + colorNum;
+                    colAttachments.Add(glAttachment);
                     colorNum++;
                     break;
             }
@@ -38,29 +39,32 @@ internal class GlFramebuffer : Framebuffer
             GlTexture tex = (GlTexture) attachment.Texture;
             if (tex.IsRenderbuffer)
             {
-                Gl.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, glAttachment, RenderbufferTarget.Renderbuffer,
+                GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, glAttachment, RenderbufferTarget.Renderbuffer,
                     tex.Handle);
             }
             else
             {
-                Gl.FramebufferTexture2D(FramebufferTarget.Framebuffer, glAttachment, TextureTarget.Texture2D, tex.Handle, 0);
+                GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, glAttachment, TextureTarget.Texture2D, tex.Handle, 0);
             }
         }
 
-        GLEnum[] drawBuffers = colAttachments.ToArray();
-        fixed (GLEnum* e = drawBuffers)
-            Gl.DrawBuffers((uint) drawBuffers.Length, e);
-
-        if (Gl.CheckFramebufferStatus(FramebufferTarget.Framebuffer) != GLEnum.FramebufferComplete)
-            throw new PieException($"OpenGL: Framebuffer is not complete: {Gl.CheckFramebufferStatus(FramebufferTarget.Framebuffer)}");
+        OpenTK.Graphics.OpenGL4.FramebufferAttachment[] drawBuffers = colAttachments.ToArray();
         
-        Gl.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+        // I really,  r e a l l y  hate this, but it's the most efficient way I can think of to reinterpret cast the array
+        // Could maybe use Unsafe.As<>() here, but it didn't feel right.
+        fixed (OpenTK.Graphics.OpenGL4.FramebufferAttachment* bufs = drawBuffers)
+            GL.DrawBuffers(drawBuffers.Length, (DrawBuffersEnum*) bufs);
+
+        if (GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer) != FramebufferErrorCode.FramebufferComplete)
+            throw new PieException($"OpenGL: Framebuffer is not complete: {GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer)}");
+        
+        GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
     }
     
     public override bool IsDisposed { get; protected set; }
     public override Size Size { get; set; }
     public override void Dispose()
     {
-        Gl.DeleteFramebuffer(Handle);
+        GL.DeleteFramebuffer(Handle);
     }
 }

--- a/src/Pie/OpenGL/GlGraphicsBuffer.cs
+++ b/src/Pie/OpenGL/GlGraphicsBuffer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Silk.NET.OpenGL;
 using static Pie.OpenGL.GlGraphicsDevice;
 
 namespace Pie.OpenGL;

--- a/src/Pie/OpenGL/GlGraphicsDevice.cs
+++ b/src/Pie/OpenGL/GlGraphicsDevice.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using OpenTK.Graphics.OpenGL4;
 using Pie.ShaderCompiler;
 
 namespace Pie.OpenGL;

--- a/src/Pie/OpenGL/GlGraphicsDevice.cs
+++ b/src/Pie/OpenGL/GlGraphicsDevice.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Pie.ShaderCompiler;
-using Silk.NET.OpenGL;
 
 namespace Pie.OpenGL;
 

--- a/src/Pie/OpenGL/GlGraphicsDevice.cs
+++ b/src/Pie/OpenGL/GlGraphicsDevice.cs
@@ -10,18 +10,17 @@ namespace Pie.OpenGL;
 
 internal sealed unsafe class GlGraphicsDevice : GraphicsDevice
 {
-    private PieGlContext _context;
-    internal static GL Gl;
+    private PieGLBindings _bindings;
     internal static bool Debug;
     internal static bool IsES;
     
     private RasterizerState _currentRState;
     private BlendState _currentBState;
     private DepthStencilState _currentDStencilState;
-    private Silk.NET.OpenGL.PrimitiveType _glType;
+    private OpenTK.Graphics.OpenGL4.PrimitiveType _glType;
     private PrimitiveType _currentPType;
     private DrawElementsType _currentEType;
-    private uint _currentShader;
+    private int _currentShader;
 
     private GlInputLayout _currentInputLayout;
     
@@ -36,10 +35,12 @@ internal sealed unsafe class GlGraphicsDevice : GraphicsDevice
     
     public GlGraphicsDevice(bool es, PieGlContext context, Size winSize, GraphicsDeviceOptions options)
     {
-        _context = context;
-        Gl = GL.GetApi(context.GetProcFunc);
+        _bindings = new PieGLBindings(context);
+        
         Debug = options.Debug;
         IsES = es;
+        
+        GL.LoadBindings(_bindings);
 
         Api = IsES ? GraphicsApi.OpenGLES : GraphicsApi.OpenGL;
         
@@ -48,23 +49,23 @@ internal sealed unsafe class GlGraphicsDevice : GraphicsDevice
             Size = winSize
         };
 
-        Gl.GetInteger(GetPName.DrawFramebufferBinding, out _defaultFramebufferId);
+        GL.GetInteger(GetPName.DrawFramebufferBinding, out _defaultFramebufferId);
 
         Viewport = new Rectangle(Point.Empty, winSize);
 
-        Adapter = new GraphicsAdapter(Gl.GetStringS(StringName.Renderer));
+        Adapter = new GraphicsAdapter(GL.GetString(StringName.Renderer));
 
         // TODO: Get the value from opengl rather than a set value.
         _currentVertexBuffers = new (GlGraphicsBuffer, uint)[16];
         
         if (Debug)
         {
-            Gl.Enable(EnableCap.DebugOutput);
-            Gl.Enable(EnableCap.DebugOutputSynchronous);
-            Gl.DebugMessageCallback(DebugCallback, null);
+            GL.Enable(EnableCap.DebugOutput);
+            GL.Enable(EnableCap.DebugOutputSynchronous);
+            GL.DebugMessageCallback(DebugCallback, IntPtr.Zero);
         }
 
-        //SpirvSupported = Gl.IsExtensionPresent("ARB_gl_spirv");
+        //SpirvSupported = GL.IsExtensionPresent("ARB_gl_spirv");
     }
     
     public override GraphicsApi Api { get; }
@@ -77,7 +78,7 @@ internal sealed unsafe class GlGraphicsDevice : GraphicsDevice
         get => _viewport;
         set
         {
-            Gl.Viewport(value.X, _framebufferSet ? value.Y : Swapchain.Size.Height - (value.Y + value.Height), (uint) value.Width, (uint) value.Height);
+            GL.Viewport(value.X, _framebufferSet ? value.Y : Swapchain.Size.Height - (value.Y + value.Height), value.Width, value.Height);
             _viewport = value;
         }
     }
@@ -89,7 +90,7 @@ internal sealed unsafe class GlGraphicsDevice : GraphicsDevice
         get => _scissor;
         set
         {
-            Gl.Scissor(value.X, Swapchain.Size.Height - (value.Y + value.Height), (uint) value.Width, (uint) value.Height);
+            GL.Scissor(value.X, Swapchain.Size.Height - (value.Y + value.Height), value.Width, value.Height);
             _scissor = value;
         }
     }
@@ -101,21 +102,21 @@ internal sealed unsafe class GlGraphicsDevice : GraphicsDevice
 
     public override void ClearColorBuffer(float r, float g, float b, float a)
     {
-        Gl.ClearColor(r, g, b, a);
-        Gl.Clear(ClearBufferMask.ColorBufferBit);
+        GL.ClearColor(r, g, b, a);
+        GL.Clear(ClearBufferMask.ColorBufferBit);
     }
 
     public override void ClearDepthStencilBuffer(ClearFlags flags, float depth, byte stencil)
     {
-        uint mask = 0;
+        ClearBufferMask mask = ClearBufferMask.None;
         if ((flags & ClearFlags.Depth) == ClearFlags.Depth)
-            mask |= (uint) ClearBufferMask.DepthBufferBit;
+            mask |= ClearBufferMask.DepthBufferBit;
         if ((flags & ClearFlags.Stencil) == ClearFlags.Stencil)
-            mask |= (uint) ClearBufferMask.StencilBufferBit;
+            mask |= ClearBufferMask.StencilBufferBit;
         
-        Gl.ClearDepth(depth);
-        Gl.ClearStencil(stencil);
-        Gl.Clear(mask);
+        GL.ClearDepth(depth);
+        GL.ClearStencil(stencil);
+        GL.Clear(mask);
     }
 
     private void InvalidateCaches()
@@ -269,7 +270,7 @@ internal sealed unsafe class GlGraphicsDevice : GraphicsDevice
         GlShader glShader = (GlShader) shader;
         if (glShader.Handle == _currentShader)
             return;
-        Gl.UseProgram(glShader.Handle);
+        GL.UseProgram(glShader.Handle);
         _currentShader = glShader.Handle;
     }
 
@@ -280,9 +281,9 @@ internal sealed unsafe class GlGraphicsDevice : GraphicsDevice
         //    return;
         //_boundTexture = (int) glTex.Handle;
         //_bindingSlot = (int) bindingSlot;
-        Gl.ActiveTexture(TextureUnit.Texture0 + (int) bindingSlot);
-        Gl.BindTexture(glTex.Target, glTex.Handle);
-        Gl.BindSampler(bindingSlot, ((GlSamplerState) state).Handle);
+        GL.ActiveTexture(TextureUnit.Texture0 + (int) bindingSlot);
+        GL.BindTexture(glTex.Target, glTex.Handle);
+        GL.BindSampler((int) bindingSlot, ((GlSamplerState) state).Handle);
     }
 
     public override void SetRasterizerState(RasterizerState state)
@@ -317,15 +318,15 @@ internal sealed unsafe class GlGraphicsDevice : GraphicsDevice
         _currentPType = type;
         _glType = type switch
         {
-            PrimitiveType.TriangleList => Silk.NET.OpenGL.PrimitiveType.Triangles,
-            PrimitiveType.TriangleStrip => Silk.NET.OpenGL.PrimitiveType.TriangleStrip,
-            PrimitiveType.LineList => Silk.NET.OpenGL.PrimitiveType.Lines,
-            PrimitiveType.LineStrip => Silk.NET.OpenGL.PrimitiveType.LineStrip,
-            PrimitiveType.PointList => Silk.NET.OpenGL.PrimitiveType.Points,
-            PrimitiveType.TriangleListAdjacency => Silk.NET.OpenGL.PrimitiveType.TrianglesAdjacency,
-            PrimitiveType.TriangleStripAdjacency => Silk.NET.OpenGL.PrimitiveType.TriangleStripAdjacency,
-            PrimitiveType.LineListAdjacency => Silk.NET.OpenGL.PrimitiveType.LinesAdjacency,
-            PrimitiveType.LineStripAdjacency => Silk.NET.OpenGL.PrimitiveType.LineStripAdjacency,
+            PrimitiveType.TriangleList => OpenTK.Graphics.OpenGL4.PrimitiveType.Triangles,
+            PrimitiveType.TriangleStrip => OpenTK.Graphics.OpenGL4.PrimitiveType.TriangleStrip,
+            PrimitiveType.LineList => OpenTK.Graphics.OpenGL4.PrimitiveType.Lines,
+            PrimitiveType.LineStrip => OpenTK.Graphics.OpenGL4.PrimitiveType.LineStrip,
+            PrimitiveType.PointList => OpenTK.Graphics.OpenGL4.PrimitiveType.Points,
+            PrimitiveType.TriangleListAdjacency => OpenTK.Graphics.OpenGL4.PrimitiveType.TrianglesAdjacency,
+            PrimitiveType.TriangleStripAdjacency => OpenTK.Graphics.OpenGL4.PrimitiveType.TriangleStripAdjacency,
+            PrimitiveType.LineListAdjacency => OpenTK.Graphics.OpenGL4.PrimitiveType.LinesAdjacency,
+            PrimitiveType.LineStripAdjacency => OpenTK.Graphics.OpenGL4.PrimitiveType.LineStripAdjacency,
             _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
         };
     }
@@ -365,20 +366,20 @@ internal sealed unsafe class GlGraphicsDevice : GraphicsDevice
 
     public override void SetUniformBuffer(uint bindingSlot, GraphicsBuffer buffer)
     {
-        Gl.BindBufferBase(BufferTargetARB.UniformBuffer, bindingSlot, ((GlGraphicsBuffer) buffer).Handle);
+        GL.BindBufferBase(BufferRangeTarget.UniformBuffer, (int) bindingSlot, ((GlGraphicsBuffer) buffer).Handle);
     }
 
     public override void SetFramebuffer(Framebuffer framebuffer)
     {
         if (framebuffer == null)
         {
-            Gl.BindFramebuffer(FramebufferTarget.Framebuffer, (uint) _defaultFramebufferId);
+            GL.BindFramebuffer(FramebufferTarget.Framebuffer, (uint) _defaultFramebufferId);
             _framebufferSet = false;
             return;
         }
 
         GlFramebuffer fb = (GlFramebuffer) framebuffer;
-        Gl.BindFramebuffer(FramebufferTarget.Framebuffer, fb.Handle);
+        GL.BindFramebuffer(FramebufferTarget.Framebuffer, fb.Handle);
         _framebufferSet = true;
     }
 
@@ -386,7 +387,7 @@ internal sealed unsafe class GlGraphicsDevice : GraphicsDevice
     {
         BindBuffersWithVao();
         
-        Gl.DrawArrays(_glType, 0, vertexCount);
+        GL.DrawArrays(_glType, 0, (int) vertexCount);
         PieMetrics.DrawCalls++;
         PieMetrics.TriCount += vertexCount / 3;
     }
@@ -395,7 +396,7 @@ internal sealed unsafe class GlGraphicsDevice : GraphicsDevice
     {
         BindBuffersWithVao();
         
-        Gl.DrawArrays(_glType, startVertex, vertexCount);
+        GL.DrawArrays(_glType, startVertex, (int) vertexCount);
         PieMetrics.DrawCalls++;
         PieMetrics.TriCount += vertexCount / 3;
     }
@@ -404,7 +405,7 @@ internal sealed unsafe class GlGraphicsDevice : GraphicsDevice
     {
         BindBuffersWithVao();
         
-        Gl.DrawElements(_glType, indexCount, _currentEType, null);
+        GL.DrawElements(_glType, (int) indexCount, _currentEType, 0);
         PieMetrics.DrawCalls++;
         PieMetrics.TriCount += indexCount / 3;
     }
@@ -413,7 +414,7 @@ internal sealed unsafe class GlGraphicsDevice : GraphicsDevice
     {
         BindBuffersWithVao();
         
-        Gl.DrawElements(_glType, indexCount, _currentEType, (void*) (startIndex * _eTypeSize));
+        GL.DrawElements(_glType, (int) indexCount, _currentEType, startIndex * _eTypeSize);
         PieMetrics.DrawCalls++;
         PieMetrics.TriCount += indexCount / 3;
     }
@@ -422,7 +423,7 @@ internal sealed unsafe class GlGraphicsDevice : GraphicsDevice
     {
         BindBuffersWithVao();
         
-        Gl.DrawElementsBaseVertex(_glType, indexCount, _currentEType, (void*) (startIndex * _eTypeSize), baseVertex);
+        GL.DrawElementsBaseVertex(_glType, (int) indexCount, _currentEType, (IntPtr) (startIndex * _eTypeSize), baseVertex);
         PieMetrics.DrawCalls++;
         PieMetrics.TriCount += indexCount / 3;
     }
@@ -431,14 +432,14 @@ internal sealed unsafe class GlGraphicsDevice : GraphicsDevice
     {
         BindBuffersWithVao();
         
-        Gl.DrawElementsInstanced(_glType, indexCount, _currentEType, null, instanceCount);
+        GL.DrawElementsInstanced(_glType, (int) indexCount, _currentEType, IntPtr.Zero, (int) instanceCount);
         PieMetrics.DrawCalls++;
         PieMetrics.TriCount += indexCount / 3 * instanceCount;
     }
 
     public override void Present(int swapInterval)
     {
-        _context.Present(swapInterval);
+        _bindings.Context.Present(swapInterval);
         InvalidateCaches();
     }
 
@@ -455,18 +456,18 @@ internal sealed unsafe class GlGraphicsDevice : GraphicsDevice
     public override void GenerateMipmaps(Texture texture)
     {
         GlTexture tex = (GlTexture) texture;
-        Gl.BindTexture(tex.Target, tex.Handle);
-        Gl.GenerateMipmap(tex.Target);
+        GL.BindTexture(tex.Target, tex.Handle);
+        GL.GenerateMipmap((GenerateMipmapTarget) tex.Target);
     }
 
     public override void Dispatch(uint groupCountX, uint groupCountY, uint groupCountZ)
     {
-        Gl.DispatchCompute(groupCountX, groupCountY, groupCountZ);
+        GL.DispatchCompute(groupCountX, groupCountY, groupCountZ);
     }
 
     public override void Flush()
     {
-        Gl.Flush();
+        GL.Flush();
     }
 
     public override void Dispose()
@@ -476,26 +477,25 @@ internal sealed unsafe class GlGraphicsDevice : GraphicsDevice
 
     private void BindBuffersWithVao()
     {
-        Gl.BindVertexArray(_currentInputLayout.VertexArray);
+        GL.BindVertexArray(_currentInputLayout.VertexArray);
 
-        for (uint i = 0; i < _currentVertexBuffers.Length; i++)
+        for (int i = 0; i < _currentVertexBuffers.Length; i++)
         {
             if (_currentVertexBuffers[i].buffer == null)
                 continue;
             
             ref (GlGraphicsBuffer buffer, uint stride) buf = ref _currentVertexBuffers[i];
             
-            Gl.BindVertexBuffer(i, buf.buffer.Handle, 0, buf.stride);
+            GL.BindVertexBuffer(i, buf.buffer.Handle, IntPtr.Zero, (int) buf.stride);
         }
         
-        Gl.BindBuffer(BufferTargetARB.ElementArrayBuffer, _currentIndexBuffer.Handle);
+        GL.BindBuffer(BufferTarget.ElementArrayBuffer, _currentIndexBuffer.Handle);
     }
 
-    private void DebugCallback(GLEnum source, GLEnum type, int id, GLEnum severity, int length, nint message, nint userParam)
+    private void DebugCallback(DebugSource source, DebugType type, int id, DebugSeverity severity, int length, nint message, nint userParam)
     {
         string msg = Marshal.PtrToStringAnsi(message);
-        DebugType debugType = (DebugType) type;
-        LogType logType = debugType switch
+        LogType logType = type switch
         {
             DebugType.DontCare => LogType.Verbose,
             DebugType.DebugTypeError => LogType.Critical,

--- a/src/Pie/OpenGL/GlInputLayout.cs
+++ b/src/Pie/OpenGL/GlInputLayout.cs
@@ -1,5 +1,5 @@
 using System;
-using static Pie.OpenGL.GlGraphicsDevice;
+using OpenTK.Graphics.OpenGL4;
 
 namespace Pie.OpenGL;
 
@@ -7,13 +7,13 @@ internal sealed class GlInputLayout : InputLayout
 {
     private readonly InputLayoutDescription[] _descriptions;
 
-    public readonly uint VertexArray;
+    public readonly int VertexArray;
 
     public GlInputLayout(InputLayoutDescription[] descriptions)
     {
         _descriptions = descriptions;
 
-        VertexArray = Gl.GenVertexArray();
+        VertexArray = GL.GenVertexArray();
         
         uint lastSlot = uint.MaxValue;
         foreach (InputLayoutDescription desc in descriptions)
@@ -30,7 +30,7 @@ internal sealed class GlInputLayout : InputLayout
 
     public unsafe void Set(uint slot)
     {
-        Gl.BindVertexArray(VertexArray);
+        GL.BindVertexArray(VertexArray);
         
         uint location = 0;
         foreach (InputLayoutDescription description in _descriptions)
@@ -41,140 +41,140 @@ internal sealed class GlInputLayout : InputLayout
                 continue;
             }
             
-            Gl.EnableVertexAttribArray(location);
+            GL.EnableVertexAttribArray(location);
             
             switch (description.Format)
             {
                 case Format.R8_UNorm:
-                    Gl.VertexAttribFormat(location, 1, VertexAttribType.UnsignedByte, true, description.Offset);
+                    GL.VertexAttribFormat(location, 1, VertexAttribType.UnsignedByte, true, description.Offset);
                     break;
                 case Format.R8G8_UNorm:
-                    Gl.VertexAttribFormat(location, 2, VertexAttribType.UnsignedByte, true, description.Offset);
+                    GL.VertexAttribFormat(location, 2, VertexAttribType.UnsignedByte, true, description.Offset);
                     break;
                 case Format.R8G8B8A8_UNorm:
-                    Gl.VertexAttribFormat(location, 4, VertexAttribType.UnsignedByte, true, description.Offset);
+                    GL.VertexAttribFormat(location, 4, VertexAttribType.UnsignedByte, true, description.Offset);
                     break;
                 case Format.B8G8R8A8_UNorm:
                     // According to the docs, the size parameter can be GL_BGRA. I'm not convinced I've implemented this
                     // correctly, but I don't really have anything to check.
-                    Gl.VertexAttribFormat(location, (int) GLEnum.Bgra, GLEnum.UnsignedByte, true, description.Offset);
+                    GL.VertexAttribFormat(location, (int) All.Bgra, VertexAttribType.UnsignedByte, true, description.Offset);
                     break;
                 case Format.R16G16B16A16_UNorm:
-                    Gl.VertexAttribFormat(location, 4, VertexAttribType.UnsignedShort, true, description.Offset);
+                    GL.VertexAttribFormat(location, 4, VertexAttribType.UnsignedShort, true, description.Offset);
                     break;
                 case Format.R16G16B16A16_SNorm:
-                    Gl.VertexAttribFormat(location, 4, VertexAttribType.Short, true, description.Offset);
+                    GL.VertexAttribFormat(location, 4, VertexAttribType.Short, true, description.Offset);
                     break;
                 case Format.R16G16B16A16_SInt:
-                    Gl.VertexAttribIFormat(location, 4, VertexAttribIType.Short, description.Offset);
+                    GL.VertexAttribIFormat(location, 4, VertexAttribIntegerType.Short, description.Offset);
                     break;
                 case Format.R16G16B16A16_UInt:
-                    Gl.VertexAttribIFormat(location, 4, VertexAttribIType.UnsignedShort, description.Offset);
+                    GL.VertexAttribIFormat(location, 4, VertexAttribIntegerType.UnsignedShort, description.Offset);
                     break;
                 case Format.R16G16B16A16_Float:
-                    Gl.VertexAttribFormat(location, 4, VertexAttribType.HalfFloat, false, description.Offset);
+                    GL.VertexAttribFormat(location, 4, VertexAttribType.HalfFloat, false, description.Offset);
                     break;
                 case Format.R32G32_SInt:
-                    Gl.VertexAttribIFormat(location, 2, VertexAttribIType.Int, description.Offset);
+                    GL.VertexAttribIFormat(location, 2, VertexAttribIntegerType.Int, description.Offset);
                     break;
                 case Format.R32G32_UInt:
-                    Gl.VertexAttribIFormat(location, 2, VertexAttribIType.UnsignedInt, description.Offset);
+                    GL.VertexAttribIFormat(location, 2, VertexAttribIntegerType.UnsignedInt, description.Offset);
                     break;
                 case Format.R32G32_Float:
-                    Gl.VertexAttribFormat(location, 2, VertexAttribType.Float, false, description.Offset);
+                    GL.VertexAttribFormat(location, 2, VertexAttribType.Float, false, description.Offset);
                     break;
                 case Format.R32G32B32_SInt:
-                    Gl.VertexAttribIFormat(location, 3, VertexAttribIType.Int, description.Offset);
+                    GL.VertexAttribIFormat(location, 3, VertexAttribIntegerType.Int, description.Offset);
                     break;
                 case Format.R32G32B32_UInt:
-                    Gl.VertexAttribIFormat(location, 3, VertexAttribIType.UnsignedInt, description.Offset);
+                    GL.VertexAttribIFormat(location, 3, VertexAttribIntegerType.UnsignedInt, description.Offset);
                     break;
                 case Format.R32G32B32_Float:
-                    Gl.VertexAttribFormat(location, 3, VertexAttribType.Float, false, description.Offset);
+                    GL.VertexAttribFormat(location, 3, VertexAttribType.Float, false, description.Offset);
                     break;
                 case Format.R32G32B32A32_SInt:
-                    Gl.VertexAttribIFormat(location, 4, VertexAttribIType.Int, description.Offset);
+                    GL.VertexAttribIFormat(location, 4, VertexAttribIntegerType.Int, description.Offset);
                     break;
                 case Format.R32G32B32A32_UInt:
-                    Gl.VertexAttribIFormat(location, 4, VertexAttribIType.UnsignedInt, description.Offset);
+                    GL.VertexAttribIFormat(location, 4, VertexAttribIntegerType.UnsignedInt, description.Offset);
                     break;
                 case Format.R32G32B32A32_Float:
-                    Gl.VertexAttribFormat(location, 4, VertexAttribType.Float, false, description.Offset);
+                    GL.VertexAttribFormat(location, 4, VertexAttribType.Float, false, description.Offset);
                     break;
                 case Format.D24_UNorm_S8_UInt:
                     throw new NotSupportedException("Depth-stencil format not supported for input layouts.");
                 case Format.R8_SNorm:
-                    Gl.VertexAttribFormat(location, 1, VertexAttribType.Byte, true, description.Offset);
+                    GL.VertexAttribFormat(location, 1, VertexAttribType.Byte, true, description.Offset);
                     break;
                 case Format.R8_SInt:
-                    Gl.VertexAttribIFormat(location, 1, VertexAttribIType.Byte, description.Offset);
+                    GL.VertexAttribIFormat(location, 1, VertexAttribIntegerType.Byte, description.Offset);
                     break;
                 case Format.R8_UInt:
-                    Gl.VertexAttribIFormat(location, 1, VertexAttribIType.UnsignedByte, description.Offset);
+                    GL.VertexAttribIFormat(location, 1, VertexAttribIntegerType.UnsignedByte, description.Offset);
                     break;
                 case Format.R8G8_SNorm:
-                    Gl.VertexAttribFormat(location, 2, VertexAttribType.Byte, true, description.Offset);
+                    GL.VertexAttribFormat(location, 2, VertexAttribType.Byte, true, description.Offset);
                     break;
                 case Format.R8G8_SInt:
-                    Gl.VertexAttribIFormat(location, 2, VertexAttribIType.Byte, description.Offset);
+                    GL.VertexAttribIFormat(location, 2, VertexAttribIntegerType.Byte, description.Offset);
                     break;
                 case Format.R8G8_UInt:
-                    Gl.VertexAttribIFormat(location, 2, VertexAttribIType.UnsignedByte, description.Offset);
+                    GL.VertexAttribIFormat(location, 2, VertexAttribIntegerType.UnsignedByte, description.Offset);
                     break;
                 case Format.R8G8B8A8_SNorm:
-                    Gl.VertexAttribFormat(location, 4, VertexAttribType.Byte, true, description.Offset);
+                    GL.VertexAttribFormat(location, 4, VertexAttribType.Byte, true, description.Offset);
                     break;
                 case Format.R8G8B8A8_SInt:
-                    Gl.VertexAttribIFormat(location, 4, VertexAttribIType.Byte, description.Offset);
+                    GL.VertexAttribIFormat(location, 4, VertexAttribIntegerType.Byte, description.Offset);
                     break;
                 case Format.R8G8B8A8_UInt:
-                    Gl.VertexAttribIFormat(location, 4, VertexAttribIType.UnsignedByte, description.Offset);
+                    GL.VertexAttribIFormat(location, 4, VertexAttribIntegerType.UnsignedByte, description.Offset);
                     break;
                 case Format.R16_UNorm:
-                    Gl.VertexAttribFormat(location, 1, VertexAttribType.UnsignedShort, true, description.Offset);
+                    GL.VertexAttribFormat(location, 1, VertexAttribType.UnsignedShort, true, description.Offset);
                     break;
                 case Format.R16_SNorm:
-                    Gl.VertexAttribFormat(location, 1, VertexAttribType.Short, true, description.Offset);
+                    GL.VertexAttribFormat(location, 1, VertexAttribType.Short, true, description.Offset);
                     break;
                 case Format.R16_SInt:
-                    Gl.VertexAttribIFormat(location, 1, VertexAttribIType.Short, description.Offset);
+                    GL.VertexAttribIFormat(location, 1, VertexAttribIntegerType.Short, description.Offset);
                     break;
                 case Format.R16_UInt:
-                    Gl.VertexAttribIFormat(location, 1, VertexAttribIType.UnsignedShort, description.Offset);
+                    GL.VertexAttribIFormat(location, 1, VertexAttribIntegerType.UnsignedShort, description.Offset);
                     break;
                 case Format.R16_Float:
-                    Gl.VertexAttribFormat(location, 1, VertexAttribType.HalfFloat, false, description.Offset);
+                    GL.VertexAttribFormat(location, 1, VertexAttribType.HalfFloat, false, description.Offset);
                     break;
                 case Format.R16G16_UNorm:
-                    Gl.VertexAttribFormat(location, 2, VertexAttribType.UnsignedShort, true, description.Offset);
+                    GL.VertexAttribFormat(location, 2, VertexAttribType.UnsignedShort, true, description.Offset);
                     break;
                 case Format.R16G16_SNorm:
-                    Gl.VertexAttribFormat(location, 2, VertexAttribType.Short, true, description.Offset);
+                    GL.VertexAttribFormat(location, 2, VertexAttribType.Short, true, description.Offset);
                     break;
                 case Format.R16G16_SInt:
-                    Gl.VertexAttribIFormat(location, 2, VertexAttribIType.Short, description.Offset);
+                    GL.VertexAttribIFormat(location, 2, VertexAttribIntegerType.Short, description.Offset);
                     break;
                 case Format.R16G16_UInt:
-                    Gl.VertexAttribIFormat(location, 2, VertexAttribIType.UnsignedShort, description.Offset);
+                    GL.VertexAttribIFormat(location, 2, VertexAttribIntegerType.UnsignedShort, description.Offset);
                     break;
                 case Format.R16G16_Float:
-                    Gl.VertexAttribFormat(location, 2, VertexAttribType.HalfFloat, false, description.Offset);
+                    GL.VertexAttribFormat(location, 2, VertexAttribType.HalfFloat, false, description.Offset);
                     break;
                 case Format.R32_SInt:
-                    Gl.VertexAttribIFormat(location, 1, VertexAttribIType.Int, description.Offset);
+                    GL.VertexAttribIFormat(location, 1, VertexAttribIntegerType.Int, description.Offset);
                     break;
                 case Format.R32_UInt:
-                    Gl.VertexAttribIFormat(location, 1, VertexAttribIType.UnsignedInt, description.Offset);
+                    GL.VertexAttribIFormat(location, 1, VertexAttribIntegerType.UnsignedInt, description.Offset);
                     break;
                 case Format.R32_Float:
-                    Gl.VertexAttribFormat(location, 1, VertexAttribType.Float, false, description.Offset);
+                    GL.VertexAttribFormat(location, 1, VertexAttribType.Float, false, description.Offset);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
             
-            Gl.VertexBindingDivisor(slot, (uint) description.InputType);
-            Gl.VertexAttribBinding(location, slot);
+            GL.VertexBindingDivisor(slot, (uint) description.InputType);
+            GL.VertexAttribBinding(location, slot);
             
             location++;
         }
@@ -190,6 +190,6 @@ internal sealed class GlInputLayout : InputLayout
             return;
         IsDisposed = true;
         
-        Gl.DeleteVertexArray(VertexArray);
+        GL.DeleteVertexArray(VertexArray);
     }
 }

--- a/src/Pie/OpenGL/GlInputLayout.cs
+++ b/src/Pie/OpenGL/GlInputLayout.cs
@@ -1,5 +1,4 @@
 using System;
-using Silk.NET.OpenGL;
 using static Pie.OpenGL.GlGraphicsDevice;
 
 namespace Pie.OpenGL;

--- a/src/Pie/OpenGL/GlRasterizerState.cs
+++ b/src/Pie/OpenGL/GlRasterizerState.cs
@@ -6,7 +6,7 @@ namespace Pie.OpenGL;
 internal sealed class GlRasterizerState : RasterizerState
 {
     private bool _cullFaceEnabled;
-    private TriangleFace _cullFaceMode;
+    private CullFaceMode _cullFaceMode;
     private FrontFaceDirection _frontFace;
     private PolygonMode _mode;
     private bool _scissor;
@@ -22,15 +22,15 @@ internal sealed class GlRasterizerState : RasterizerState
             _cullFaceEnabled = true;
             _cullFaceMode = description.CullFace switch
             {
-                CullFace.Front => TriangleFace.Front,
-                CullFace.Back => TriangleFace.Back,
+                CullFace.Front => CullFaceMode.Front,
+                CullFace.Back => CullFaceMode.Back,
                 _ => throw new ArgumentOutOfRangeException()
             };
         }
 
         _frontFace = description.CullDirection switch
         {
-            CullDirection.Clockwise => FrontFaceDirection.CW,
+            CullDirection.Clockwise => FrontFaceDirection.Cw,
             CullDirection.CounterClockwise => FrontFaceDirection.Ccw,
             _ => throw new ArgumentOutOfRangeException()
         };
@@ -61,8 +61,8 @@ internal sealed class GlRasterizerState : RasterizerState
         
         GL.FrontFace(_frontFace);
 
-        if (!IsES)
-            GL.PolygonMode(TriangleFace.FrontAndBack, _mode);
+        if (!GlGraphicsDevice.IsES)
+            GL.PolygonMode(MaterialFace.FrontAndBack, _mode);
         
         if (_scissor)
             GL.Enable(EnableCap.ScissorTest);

--- a/src/Pie/OpenGL/GlRasterizerState.cs
+++ b/src/Pie/OpenGL/GlRasterizerState.cs
@@ -1,5 +1,4 @@
 using System;
-using Silk.NET.OpenGL;
 using static Pie.OpenGL.GlGraphicsDevice;
 
 namespace Pie.OpenGL;

--- a/src/Pie/OpenGL/GlRasterizerState.cs
+++ b/src/Pie/OpenGL/GlRasterizerState.cs
@@ -1,5 +1,5 @@
 using System;
-using static Pie.OpenGL.GlGraphicsDevice;
+using OpenTK.Graphics.OpenGL4;
 
 namespace Pie.OpenGL;
 
@@ -52,22 +52,22 @@ internal sealed class GlRasterizerState : RasterizerState
     public void Set()
     {
         if (!_cullFaceEnabled)
-            Gl.Disable(EnableCap.CullFace);
+            GL.Disable(EnableCap.CullFace);
         else
         {
-            Gl.Enable(EnableCap.CullFace);
-            Gl.CullFace(_cullFaceMode);
+            GL.Enable(EnableCap.CullFace);
+            GL.CullFace(_cullFaceMode);
         }
         
-        Gl.FrontFace(_frontFace);
+        GL.FrontFace(_frontFace);
 
         if (!IsES)
-            Gl.PolygonMode(TriangleFace.FrontAndBack, _mode);
+            GL.PolygonMode(TriangleFace.FrontAndBack, _mode);
         
         if (_scissor)
-            Gl.Enable(EnableCap.ScissorTest);
+            GL.Enable(EnableCap.ScissorTest);
         else
-            Gl.Disable(EnableCap.ScissorTest);
+            GL.Disable(EnableCap.ScissorTest);
     }
     
     public override void Dispose()

--- a/src/Pie/OpenGL/GlSamplerState.cs
+++ b/src/Pie/OpenGL/GlSamplerState.cs
@@ -1,5 +1,4 @@
 using System;
-using Silk.NET.OpenGL;
 using static Pie.OpenGL.GlGraphicsDevice;
 
 namespace Pie.OpenGL;

--- a/src/Pie/OpenGL/GlSamplerState.cs
+++ b/src/Pie/OpenGL/GlSamplerState.cs
@@ -1,17 +1,17 @@
 using System;
-using static Pie.OpenGL.GlGraphicsDevice;
+using OpenTK.Graphics.OpenGL4;
 
 namespace Pie.OpenGL;
 
 internal sealed class GlSamplerState : SamplerState
 {
-    public readonly uint Handle;
+    public readonly int Handle;
 
     public unsafe GlSamplerState(SamplerStateDescription description)
     {
         Description = description;
         
-        Handle = Gl.GenSampler();
+        Handle = GL.GenSampler();
 
         TextureMinFilter minFilter;
         TextureMagFilter magFilter;
@@ -59,26 +59,26 @@ internal sealed class GlSamplerState : SamplerState
                 throw new ArgumentOutOfRangeException();
         }
         
-        Gl.SamplerParameter(Handle, SamplerParameterI.MinFilter, (int) minFilter);
-        Gl.SamplerParameter(Handle, SamplerParameterI.MagFilter, (int) magFilter);
-        Gl.SamplerParameter(Handle, SamplerParameterI.WrapS, (int) GetWrapModeFromTextureAddress(description.AddressU));
-        Gl.SamplerParameter(Handle, SamplerParameterI.WrapT, (int) GetWrapModeFromTextureAddress(description.AddressV));
-        Gl.SamplerParameter(Handle, SamplerParameterI.WrapR, (int) GetWrapModeFromTextureAddress(description.AddressW));
-        Gl.SamplerParameter(Handle, SamplerParameterF.LodBias, 0);
+        GL.SamplerParameter(Handle, SamplerParameterName.TextureMinFilter, (int) minFilter);
+        GL.SamplerParameter(Handle, SamplerParameterName.TextureMagFilter, (int) magFilter);
+        GL.SamplerParameter(Handle, SamplerParameterName.TextureWrapS, (int) GetWrapModeFromTextureAddress(description.AddressU));
+        GL.SamplerParameter(Handle, SamplerParameterName.TextureWrapT, (int) GetWrapModeFromTextureAddress(description.AddressV));
+        GL.SamplerParameter(Handle, SamplerParameterName.TextureWrapR, (int) GetWrapModeFromTextureAddress(description.AddressW));
+        GL.SamplerParameter(Handle, SamplerParameterName.TextureLodBias, 0);
         // OpenGL doesn't have a specific anisotropic filter mode, so to make it behave like DirectX we just ignore the
         // given anisotropy if we're not using anisotropic filtering.
         if (description.Filter == TextureFilter.Anisotropic)
-            Gl.SamplerParameter(Handle, SamplerParameterF.MaxAnisotropy, description.MaxAnisotropy);
-        Gl.SamplerParameter(Handle, SamplerParameterI.CompareFunc, (int) DepthFunction.Lequal);
+            GL.SamplerParameter(Handle, SamplerParameterName.TextureMaxAnisotropyExt, description.MaxAnisotropy);
+        GL.SamplerParameter(Handle, SamplerParameterName.TextureCompareFunc, (int) DepthFunction.Lequal);
         float[] bColor =
         {
             description.BorderColor.R / 255f, description.BorderColor.G / 255f, description.BorderColor.B / 255f,
             description.BorderColor.A / 255f
         };
         fixed (float* border = bColor)
-            Gl.SamplerParameter(Handle, SamplerParameterF.BorderColor, border);
-        Gl.SamplerParameter(Handle, SamplerParameterF.MinLod, description.MinLOD);
-        Gl.SamplerParameter(Handle, SamplerParameterF.MaxLod, description.MaxLOD);
+            GL.SamplerParameter(Handle, SamplerParameterName.TextureBorderColor, border);
+        GL.SamplerParameter(Handle,SamplerParameterName.TextureMinLod, description.MinLOD);
+        GL.SamplerParameter(Handle, SamplerParameterName.TextureMaxLod, description.MaxLOD);
     }
     
     public override bool IsDisposed { get; protected set; }
@@ -88,7 +88,7 @@ internal sealed class GlSamplerState : SamplerState
         if (IsDisposed)
             return;
         IsDisposed = true;
-        Gl.DeleteSampler(Handle);
+        GL.DeleteSampler(Handle);
     }
 
     private static TextureWrapMode GetWrapModeFromTextureAddress(TextureAddress address)

--- a/src/Pie/OpenGL/GlShader.cs
+++ b/src/Pie/OpenGL/GlShader.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.Numerics;
-using System.Text;
 using Pie.ShaderCompiler;
-using Silk.NET.OpenGL;
 using static Pie.OpenGL.GlGraphicsDevice;
 
 namespace Pie.OpenGL;

--- a/src/Pie/OpenGL/GlShader.cs
+++ b/src/Pie/OpenGL/GlShader.cs
@@ -1,6 +1,7 @@
 using System;
+using System.Text;
+using OpenTK.Graphics.OpenGL4;
 using Pie.ShaderCompiler;
-using static Pie.OpenGL.GlGraphicsDevice;
 
 namespace Pie.OpenGL;
 
@@ -8,13 +9,13 @@ internal sealed class GlShader : Shader
 {
     public override bool IsDisposed { get; protected set; }
 
-    public uint Handle;
+    public int Handle;
 
     public unsafe GlShader(ShaderAttachment[] attachments, SpecializationConstant[] constants)
     {
-        Handle = Gl.CreateProgram();
+        Handle = GL.CreateProgram();
 
-        uint* shaders = stackalloc uint[attachments.Length];
+        int* shaders = stackalloc int[attachments.Length];
         
         for (int i = 0; i < attachments.Length; i++)
         {
@@ -29,45 +30,44 @@ internal sealed class GlShader : Shader
                 _ => throw new ArgumentOutOfRangeException()
             };
 
-            uint shader = Gl.CreateShader(type);
+            int shader = GL.CreateShader(type);
             shaders[i] = shader;
 
             CompilerResult result = Compiler.FromSpirv(Language.GLSL, attachment.Stage, attachment.Spirv,
                 attachment.EntryPoint, constants);
             byte[] res = result.Result;
             
-            fixed (byte* rPtr = res)
-                Gl.ShaderSource(shader, 1, rPtr, res.Length);
+            GL.ShaderSource(shader, Encoding.UTF8.GetString(res));
             
-            Gl.CompileShader(shader);
+            GL.CompileShader(shader);
 
-            Gl.GetShader(shader, ShaderParameterName.CompileStatus, out int compStatus);
-            if (compStatus != (int) GLEnum.True)
+            GL.GetShader(shader, ShaderParameter.CompileStatus, out int compStatus);
+            if (compStatus != (int) All.True)
             {
                 throw new PieException($"OpenGL: Failed to compile {attachment.Stage} shader! " +
-                                       Gl.GetShaderInfoLog(shader));
+                                       GL.GetShaderInfoLog(shader));
             }
             
-            Gl.AttachShader(Handle, shader);
+            GL.AttachShader(Handle, shader);
         }
         
-        Gl.LinkProgram(Handle);
+        GL.LinkProgram(Handle);
 
-        Gl.GetProgram(Handle, ProgramPropertyARB.LinkStatus, out int linkStatus);
-        if (linkStatus != (int) GLEnum.True)
-            throw new PieException("OpenGL: Failed to link program! " + Gl.GetProgramInfoLog(Handle));
+        GL.GetProgram(Handle, GetProgramParameterName.LinkStatus, out int linkStatus);
+        if (linkStatus != (int) All.True)
+            throw new PieException("OpenGL: Failed to link program! " + GL.GetProgramInfoLog(Handle));
 
         for (int i = 0; i < attachments.Length; i++)
         {
-            uint shader = shaders[i];
+            int shader = shaders[i];
             
-            Gl.DetachShader(Handle, shader);
-            Gl.DeleteShader(shader);
+            GL.DetachShader(Handle, shader);
+            GL.DeleteShader(shader);
         }
     }
 
     public override void Dispose()
     {
-        Gl.DeleteProgram(Handle);
+        GL.DeleteProgram(Handle);
     }
 }

--- a/src/Pie/OpenGL/GlTexture.cs
+++ b/src/Pie/OpenGL/GlTexture.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Drawing;
-using Silk.NET.OpenGL;
 using static Pie.OpenGL.GlGraphicsDevice;
 
 namespace Pie.OpenGL;

--- a/src/Pie/OpenGL/GlTexture.cs
+++ b/src/Pie/OpenGL/GlTexture.cs
@@ -1,11 +1,11 @@
 using System;
-using static Pie.OpenGL.GlGraphicsDevice;
+using OpenTK.Graphics.OpenGL4;
 
 namespace Pie.OpenGL;
 
 internal sealed class GlTexture : Texture
 {
-    public uint Handle;
+    public int Handle;
     public bool IsRenderbuffer;
     public TextureTarget Target;
 
@@ -14,7 +14,7 @@ internal sealed class GlTexture : Texture
     private PixelType _pixelType;
     private bool _compressed;
 
-    public unsafe GlTexture(uint handle, PixelFormat fmt, InternalFormat iFmt, PixelType pixelType, bool compressed, TextureDescription description, bool isRenderbuffer, TextureTarget target)
+    public GlTexture(int handle, PixelFormat fmt, InternalFormat iFmt, PixelType pixelType, bool compressed, TextureDescription description, bool isRenderbuffer, TextureTarget target)
     {
         Handle = handle;
         _fmt = fmt;
@@ -30,7 +30,7 @@ internal sealed class GlTexture : Texture
 
     public static unsafe Texture CreateTexture(TextureDescription description, void* data)
     {
-        if (IsES && description.TextureType == TextureType.Texture1D)
+        if (GlGraphicsDevice.IsES && description.TextureType == TextureType.Texture1D)
             throw new NotSupportedException("OpenGL ES does not support 1D textures.");
         
         bool isRenderbuffer = (description.Usage & TextureUsage.Framebuffer) == TextureUsage.Framebuffer &&
@@ -64,8 +64,8 @@ internal sealed class GlTexture : Texture
                 type = PixelType.UnsignedByte;
                 break;
             case Format.R8G8_UNorm:
-                fmt = PixelFormat.RG;
-                iFmt = InternalFormat.RG8;
+                fmt = PixelFormat.Rg;
+                iFmt = InternalFormat.Rg8;
                 type = PixelType.UnsignedByte;
                 break;
             case Format.R16G16B16A16_Float:
@@ -85,7 +85,7 @@ internal sealed class GlTexture : Texture
                 break;
             case Format.R16G16B16A16_SNorm:
                 fmt = PixelFormat.Rgba;
-                iFmt = InternalFormat.Rgba16SNorm;
+                iFmt = (InternalFormat) All.Rgba16Snorm;
                 type = PixelType.Byte;
                 break;
             case Format.R16G16B16A16_SInt:
@@ -99,18 +99,18 @@ internal sealed class GlTexture : Texture
                 type = PixelType.UnsignedByte;
                 break;
             case Format.R32G32_SInt:
-                fmt = PixelFormat.RG;
-                iFmt = InternalFormat.RG32i;
+                fmt = PixelFormat.Rg;
+                iFmt = InternalFormat.Rg32i;
                 type = PixelType.Int;
                 break;
             case Format.R32G32_UInt:
-                fmt = PixelFormat.RG;
-                iFmt = InternalFormat.RG32ui;
+                fmt = PixelFormat.Rg;
+                iFmt = InternalFormat.Rg32ui;
                 type = PixelType.UnsignedInt;
                 break;
             case Format.R32G32_Float:
-                fmt = PixelFormat.RG;
-                iFmt = InternalFormat.RG32f;
+                fmt = PixelFormat.Rg;
+                iFmt = InternalFormat.Rg32f;
                 type = PixelType.Float;
                 break;
             case Format.R32G32B32_SInt:
@@ -125,7 +125,7 @@ internal sealed class GlTexture : Texture
                 break;
             case Format.R32G32B32_Float:
                 fmt = PixelFormat.Rgb;
-                iFmt = InternalFormat.Rgb32f;
+                iFmt = (InternalFormat) All.Rgb32f;
                 type = PixelType.Float;
                 break;
             case Format.R32G32B32A32_SInt:
@@ -140,7 +140,7 @@ internal sealed class GlTexture : Texture
                 break;
             case Format.R8_SNorm:
                 fmt = PixelFormat.Red;
-                iFmt = InternalFormat.R8SNorm;
+                iFmt = InternalFormat.R8Snorm;
                 type = PixelType.Byte;
                 break;
             case Format.R8_SInt:
@@ -154,23 +154,23 @@ internal sealed class GlTexture : Texture
                 type = PixelType.UnsignedByte;
                 break;
             case Format.R8G8_SNorm:
-                fmt = PixelFormat.RG;
-                iFmt = InternalFormat.RG8SNorm;
+                fmt = PixelFormat.Rg;
+                iFmt = InternalFormat.Rg8Snorm;
                 type = PixelType.Byte;
                 break;
             case Format.R8G8_SInt:
-                fmt = PixelFormat.RG;
-                iFmt = InternalFormat.RG8i;
+                fmt = PixelFormat.Rg;
+                iFmt = InternalFormat.Rg8i;
                 type = PixelType.Byte;
                 break;
             case Format.R8G8_UInt:
-                fmt = PixelFormat.RG;
-                iFmt = InternalFormat.RG8ui;
+                fmt = PixelFormat.Rg;
+                iFmt = InternalFormat.Rg8ui;
                 type = PixelType.UnsignedByte;
                 break;
             case Format.R8G8B8A8_SNorm:
                 fmt = PixelFormat.Rgb;
-                iFmt = InternalFormat.Rgba8SNorm;
+                iFmt = InternalFormat.Rgba8Snorm;
                 type = PixelType.Byte;
                 break;
             case Format.R8G8B8A8_SInt:
@@ -190,7 +190,7 @@ internal sealed class GlTexture : Texture
                 break;
             case Format.R16_SNorm:
                 fmt = PixelFormat.Red;
-                iFmt = InternalFormat.R16SNorm;
+                iFmt = InternalFormat.R16Snorm;
                 type = PixelType.Short;
                 break;
             case Format.R16_SInt:
@@ -209,28 +209,28 @@ internal sealed class GlTexture : Texture
                 type = PixelType.Float;
                 break;
             case Format.R16G16_UNorm:
-                fmt = PixelFormat.RG;
-                iFmt = InternalFormat.RG16;
+                fmt = PixelFormat.Rg;
+                iFmt = InternalFormat.Rg16;
                 type = PixelType.UnsignedShort;
                 break;
             case Format.R16G16_SNorm:
-                fmt = PixelFormat.RG;
-                iFmt = InternalFormat.RG16SNorm;
+                fmt = PixelFormat.Rg;
+                iFmt = InternalFormat.Rg16Snorm;
                 type = PixelType.Short;
                 break;
             case Format.R16G16_SInt:
-                fmt = PixelFormat.RG;
-                iFmt = InternalFormat.RG16i;
+                fmt = PixelFormat.Rg;
+                iFmt = InternalFormat.Rg16i;
                 type = PixelType.Short;
                 break;
             case Format.R16G16_UInt:
-                fmt = PixelFormat.RG;
-                iFmt = InternalFormat.RG16ui;
+                fmt = PixelFormat.Rg;
+                iFmt = InternalFormat.Rg16ui;
                 type = PixelType.UnsignedShort;
                 break;
             case Format.R16G16_Float:
-                fmt = PixelFormat.RG;
-                iFmt = InternalFormat.RG16f;
+                fmt = PixelFormat.Rg;
+                iFmt = InternalFormat.Rg16f;
                 type = PixelType.Float;
                 break;
             case Format.R32_SInt:
@@ -270,37 +270,37 @@ internal sealed class GlTexture : Texture
                 break;
             case Format.BC1_UNorm:
                 fmt = PixelFormat.Rgba;
-                iFmt = InternalFormat.CompressedRgbaS3TCDxt1Ext;
+                iFmt = InternalFormat.CompressedRgbaS3tcDxt1Ext;
                 type = PixelType.UnsignedByte;
                 compressed = true;
                 break;
             case Format.BC1_UNorm_SRgb:
                 fmt = PixelFormat.Rgba;
-                iFmt = InternalFormat.CompressedSrgbS3TCDxt1Ext;
+                iFmt = InternalFormat.CompressedSrgbS3tcDxt1Ext;
                 type = PixelType.UnsignedByte;
                 compressed = true;
                 break;
             case Format.BC2_UNorm:
                 fmt = PixelFormat.Rgba;
-                iFmt = InternalFormat.CompressedRgbaS3TCDxt3Ext;
+                iFmt = InternalFormat.CompressedRgbaS3tcDxt3Ext;
                 type = PixelType.UnsignedByte;
                 compressed = true;
                 break;
             case Format.BC2_UNorm_SRgb:
                 fmt = PixelFormat.Rgba;
-                iFmt = InternalFormat.CompressedSrgbAlphaS3TCDxt3Ext;
+                iFmt = InternalFormat.CompressedSrgbAlphaS3tcDxt3Ext;
                 type = PixelType.UnsignedByte;
                 compressed = true;
                 break;
             case Format.BC3_UNorm:
                 fmt = PixelFormat.Rgba;
-                iFmt = InternalFormat.CompressedRgbaS3TCDxt5Ext;
+                iFmt = InternalFormat.CompressedRgbaS3tcDxt5Ext;
                 type = PixelType.UnsignedByte;
                 compressed = true;
                 break;
             case Format.BC3_UNorm_SRgb:
                 fmt = PixelFormat.Rgba;
-                iFmt = InternalFormat.CompressedSrgbAlphaS3TCDxt5Ext;
+                iFmt = InternalFormat.CompressedSrgbAlphaS3tcDxt5Ext;
                 type = PixelType.UnsignedByte;
                 compressed = true;
                 break;
@@ -317,14 +317,14 @@ internal sealed class GlTexture : Texture
                 compressed = true;
                 break;
             case Format.BC5_UNorm:
-                fmt = PixelFormat.RG;
-                iFmt = InternalFormat.CompressedRGRgtc2;
+                fmt = PixelFormat.Rg;
+                iFmt = InternalFormat.CompressedRgRgtc2;
                 type = PixelType.UnsignedByte;
                 compressed = true;
                 break;
             case Format.BC5_SNorm:
-                fmt = PixelFormat.RG;
-                iFmt = InternalFormat.CompressedSignedRGRgtc2;
+                fmt = PixelFormat.Rg;
+                iFmt = InternalFormat.CompressedSignedRgRgtc2;
                 type = PixelType.UnsignedByte;
                 compressed = true;
                 break;
@@ -358,18 +358,18 @@ internal sealed class GlTexture : Texture
 
         TextureTarget target = TextureTarget.Texture2D;
         
-        uint handle;
+        int handle;
         if (isRenderbuffer)
         {
-            handle = Gl.GenRenderbuffer();
-            if (Debug)
+            handle = GL.GenRenderbuffer();
+            if (GlGraphicsDevice.Debug)
                 PieLog.Log(LogType.Info, "Texture will be created as a Renderbuffer.");
-            Gl.BindRenderbuffer(RenderbufferTarget.Renderbuffer, handle);
-            Gl.RenderbufferStorage(RenderbufferTarget.Renderbuffer, iFmt, (uint) description.Width, (uint) description.Height);
+            GL.BindRenderbuffer(RenderbufferTarget.Renderbuffer, handle);
+            GL.RenderbufferStorage(RenderbufferTarget.Renderbuffer, (RenderbufferStorage) iFmt, description.Width, description.Height);
         }
         else
         {
-            handle = Gl.GenTexture();
+            handle = GL.GenTexture();
             
             target = description.TextureType switch
             {
@@ -380,7 +380,7 @@ internal sealed class GlTexture : Texture
                 _ => throw new ArgumentOutOfRangeException()
             };
         
-            Gl.BindTexture(target, handle);
+            GL.BindTexture(target, handle);
             PieUtils.CalculatePitch(description.Format, description.Width, out int bpp);
 
             // Calculate the number of mip levels if the description's value is 0.
@@ -389,28 +389,28 @@ internal sealed class GlTexture : Texture
                 : description.MipLevels;
 
             // Allocate the texture based on the target and number of mip levels.
-            AllocateTexture(target, (uint) mipLevels, (SizedInternalFormat) iFmt, description);
+            AllocateTexture(target, mipLevels, (SizedInternalFormat) iFmt, description);
 
             if (data != null)
             {
                 // The current offset in bytes to look at the data.
-                uint currentOffset = 0;
+                int currentOffset = 0;
 
                 for (int a = 0; a < description.ArraySize * (description.TextureType == TextureType.Cubemap ? 6 : 1); a++)
                 {
-                    uint width = (uint) description.Width;
+                    int width = description.Width;
                     // While width must always have a width >= 1, height and depth may not always. If the height or depth
                     // are 0, this will cause the size calculation to fail, so we must set it to 1 here.
-                    uint height = (uint) PieUtils.Max(description.Height, 1);
-                    uint depth = (uint) PieUtils.Max(description.Depth, 1);
+                    int height = PieUtils.Max(description.Height, 1);
+                    int depth = PieUtils.Max(description.Depth, 1);
 
                     // The loop must run at least once, even if the mip levels are 0.
                     for (int i = 0; i < PieUtils.Max(1, description.MipLevels); i++)
                     {
-                        uint currSize = (uint) (width * height * depth * (bpp / 8f));
+                        int currSize = (int) (width * height * depth * (bpp / 8f));
 
                         UpdateSubTexture(target, i, a, 0, 0, 0, width, height, depth, compressed, iFmt, fmt, currSize,
-                            type, (byte*) data + currentOffset);
+                            type, (IntPtr) ((byte*) data + currentOffset));
 
                         currentOffset += currSize;
 
@@ -430,7 +430,7 @@ internal sealed class GlTexture : Texture
             }
 
             if (description.MipLevels != 0)
-                Gl.TexParameter(target, TextureParameterName.TextureMaxLevel, description.MipLevels - 1);
+                GL.TexParameter(target, TextureParameterName.TextureMaxLevel, description.MipLevels - 1);
         }
 
         return new GlTexture(handle, fmt, iFmt, type, compressed, description, isRenderbuffer, target);
@@ -441,15 +441,15 @@ internal sealed class GlTexture : Texture
 
     public unsafe void Update(int x, int y, int z, int width, int height, int depth, int mipLevel, int arrayIndex, void* data)
     {
-        Gl.BindTexture(Target, Handle);
+        GL.BindTexture(Target, Handle);
 
         TextureDescription description = Description;
         PieUtils.CalculatePitch(description.Format, description.Width, out int bpp);
-        uint size = (uint) (PieUtils.Max(description.Width, 1) * PieUtils.Max(description.Height, 1) *
+        int size = (int) (PieUtils.Max(description.Width, 1) * PieUtils.Max(description.Height, 1) *
                             PieUtils.Max(description.Depth, 1) * (bpp / 8f));
 
-        UpdateSubTexture(Target, mipLevel, arrayIndex, x, y, z, (uint) width, (uint) height, (uint) depth,
-            _compressed, _iFmt, _fmt, size, _pixelType, data);
+        UpdateSubTexture(Target, mipLevel, arrayIndex, x, y, z, width, height, depth, _compressed, _iFmt, _fmt, size,
+            _pixelType, (IntPtr) data);
     }
 
     public override void Dispose()
@@ -458,34 +458,34 @@ internal sealed class GlTexture : Texture
             return;
         IsDisposed = true;
         if (IsRenderbuffer)
-            Gl.DeleteRenderbuffer(Handle);
+            GL.DeleteRenderbuffer(Handle);
         else
-            Gl.DeleteTexture(Handle);
+            GL.DeleteTexture(Handle);
     }
 
-    private static void AllocateTexture(TextureTarget target, uint mipLevels, SizedInternalFormat format, in TextureDescription description)
+    private static void AllocateTexture(TextureTarget target, int mipLevels, SizedInternalFormat format, in TextureDescription description)
     {
         switch (target)
         {
             case TextureTarget.Texture1D:
-                Gl.TexStorage1D(target, mipLevels, format, (uint) description.Width);
+                GL.TexStorage1D((TextureTarget1d) target, mipLevels, format, description.Width);
                 break;
             case TextureTarget.Texture2D:
-                Gl.TexStorage2D(target, mipLevels, format, (uint) description.Width, (uint) description.Height);
+                GL.TexStorage2D((TextureTarget2d) target, mipLevels, format, description.Width, description.Height);
                 break;
             case TextureTarget.Texture3D:
-                Gl.TexStorage3D(target, mipLevels, format, (uint) description.Width, (uint) description.Height,
-                    (uint) description.Depth);
+                GL.TexStorage3D((TextureTarget3d) target, mipLevels, format, description.Width, description.Height,
+                    description.Depth);
                 break;
             case TextureTarget.Texture1DArray:
-                Gl.TexStorage2D(target, mipLevels, format, (uint) description.Width, (uint) description.ArraySize);
+                GL.TexStorage2D((TextureTarget2d) target, mipLevels, format, description.Width, description.ArraySize);
                 break;
             case TextureTarget.Texture2DArray:
-                Gl.TexStorage3D(target, mipLevels, format, (uint) description.Width, (uint) description.Height,
-                    (uint) description.ArraySize);
+                GL.TexStorage3D((TextureTarget3d) target, mipLevels, format, description.Width, description.Height,
+                    description.ArraySize);
                 break;
             case TextureTarget.TextureCubeMap:
-                Gl.TexStorage2D(target, mipLevels, format, (uint) description.Width, (uint) description.Height);
+                GL.TexStorage2D((TextureTarget2d) target, mipLevels, format, description.Width, description.Height);
                 break;
             
             default:
@@ -493,9 +493,9 @@ internal sealed class GlTexture : Texture
         }
     }
 
-    private static unsafe void UpdateSubTexture(TextureTarget target, int level, int arrayIndex, int x, int y, int z,
-        uint width, uint height, uint depth, bool isCompressed, InternalFormat glIFormat, PixelFormat glFormat,
-        uint size, PixelType type, void* data)
+    private static void UpdateSubTexture(TextureTarget target, int level, int arrayIndex, int x, int y, int z,
+        int width, int height, int depth, bool isCompressed, InternalFormat glIFormat, PixelFormat glFormat,
+        int size, PixelType type, IntPtr data)
     {
         if (isCompressed && size < 16)
             return;
@@ -504,44 +504,44 @@ internal sealed class GlTexture : Texture
         {
             case TextureTarget.Texture1D:
                 if (isCompressed)
-                    Gl.CompressedTexSubImage1D(target, level, x, width, glIFormat, size, data);
+                    GL.CompressedTexSubImage1D(target, level, x, width, (PixelFormat) glIFormat, size, data);
                 else
-                    Gl.TexSubImage1D(target, level, x, width, glFormat, type, data);
+                    GL.TexSubImage1D(target, level, x, width, glFormat, type, data);
                 break;
             case TextureTarget.Texture2D:
                 if (isCompressed)
-                    Gl.CompressedTexSubImage2D(target, level, x, y, width, height, glIFormat, size, data);
+                    GL.CompressedTexSubImage2D(target, level, x, y, width, height, (PixelFormat) glIFormat, size, data);
                 else
-                    Gl.TexSubImage2D(target, level, x, y, width, height, glFormat, type, data);
+                    GL.TexSubImage2D(target, level, x, y, width, height, glFormat, type, data);
                 break;
             case TextureTarget.Texture3D:
                 if (isCompressed)
-                    Gl.CompressedTexSubImage3D(target, level, x, y, z, width, height, depth, glIFormat, size, data);
+                    GL.CompressedTexSubImage3D(target, level, x, y, z, width, height, depth, (PixelFormat) glIFormat, size, data);
                 else
-                    Gl.TexSubImage3D(target, level, x, y, z, width, height, depth, glFormat, type, data);
+                    GL.TexSubImage3D(target, level, x, y, z, width, height, depth, glFormat, type, data);
                 break;
             case TextureTarget.Texture1DArray:
                 if (isCompressed)
-                    Gl.CompressedTexSubImage2D(target, level, x, arrayIndex, width, 1, glIFormat, size, data);
+                    GL.CompressedTexSubImage2D(target, level, x, arrayIndex, width, 1, (PixelFormat) glIFormat, size, data);
                 else
-                    Gl.TexSubImage2D(target, level, x, arrayIndex, width, 1, glFormat, type, data);
+                    GL.TexSubImage2D(target, level, x, arrayIndex, width, 1, glFormat, type, data);
                 break;
             case TextureTarget.Texture2DArray:
                 if (isCompressed)
                 {
-                    Gl.CompressedTexSubImage3D(target, level, x, y, arrayIndex, width, height, 1, glIFormat, size,
+                    GL.CompressedTexSubImage3D(target, level, x, y, arrayIndex, width, height, 1, (PixelFormat) glIFormat, size,
                         data);
                 }
                 else
-                    Gl.TexSubImage3D(target, level, x, y, arrayIndex, width, height, 1, glFormat, type, data);
+                    GL.TexSubImage3D(target, level, x, y, arrayIndex, width, height, 1, glFormat, type, data);
                 break;
             case TextureTarget.TextureCubeMap:
                 TextureTarget cubemapTarget = TextureTarget.TextureCubeMapPositiveX + arrayIndex;
 
                 if (isCompressed)
-                    Gl.CompressedTexSubImage2D(cubemapTarget, level, x, y, width, height, glIFormat, size, data);
+                    GL.CompressedTexSubImage2D(cubemapTarget, level, x, y, width, height, (PixelFormat) glIFormat, size, data);
                 else
-                    Gl.TexSubImage2D(cubemapTarget, level, x, y, width, height, glFormat, type, data);
+                    GL.TexSubImage2D(cubemapTarget, level, x, y, width, height, glFormat, type, data);
                 break;
         }
     }

--- a/src/Pie/OpenGL/GlUtils.cs
+++ b/src/Pie/OpenGL/GlUtils.cs
@@ -1,5 +1,4 @@
 using System;
-using Silk.NET.OpenGL;
 
 namespace Pie.OpenGL;
 

--- a/src/Pie/OpenGL/GlUtils.cs
+++ b/src/Pie/OpenGL/GlUtils.cs
@@ -1,16 +1,17 @@
 using System;
+using OpenTK.Graphics.OpenGL4;
 
 namespace Pie.OpenGL;
 
 internal static class GlUtils
 {
-    internal static MapBufferAccessMask ToGlMapMode(this MapMode mode)
+    internal static BufferAccessMask ToGlMapMode(this MapMode mode)
     {
         return mode switch
         {
-            MapMode.Read => MapBufferAccessMask.ReadBit,
-            MapMode.Write => MapBufferAccessMask.WriteBit,
-            MapMode.ReadWrite => MapBufferAccessMask.ReadBit | MapBufferAccessMask.WriteBit,
+            MapMode.Read => BufferAccessMask.MapReadBit,
+            MapMode.Write => BufferAccessMask.MapWriteBit,
+            MapMode.ReadWrite => BufferAccessMask.MapReadBit | BufferAccessMask.MapWriteBit,
             _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
         };
     }

--- a/src/Pie/OpenGL/PieGLBindings.cs
+++ b/src/Pie/OpenGL/PieGLBindings.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using OpenTK;
+
+namespace Pie.OpenGL;
+
+internal class PieGLBindings : IBindingsContext
+{
+    public PieGlContext Context;
+    
+    public PieGLBindings(PieGlContext context)
+    {
+        Context = context;
+    }
+
+    public IntPtr GetProcAddress(string procName)
+        => Context.GetProcAddress(procName);
+}

--- a/src/Pie/Pie.csproj
+++ b/src/Pie/Pie.csproj
@@ -19,6 +19,7 @@
 
     <ItemGroup>
       <!--<PackageReference Include="OpenTK.Graphics" Version="4.8.2" />-->
+      <PackageReference Include="OpenTK.Graphics" Version="4.8.2" />
       <PackageReference Include="Vortice.D3DCompiler" Version="3.2.0" />
       <PackageReference Include="Vortice.Direct3D11" Version="3.2.0" />
       <!--<PackageReference Include="Vortice.DXGI" Version="3.3.4" />-->

--- a/src/Pie/Pie.csproj
+++ b/src/Pie/Pie.csproj
@@ -19,6 +19,7 @@
 
     <ItemGroup>
       <!--<PackageReference Include="OpenTK.Graphics" Version="4.8.2" />-->
+      <PackageReference Include="Vortice.D3DCompiler" Version="3.2.0" />
       <PackageReference Include="Vortice.Direct3D11" Version="3.2.0" />
       <!--<PackageReference Include="Vortice.DXGI" Version="3.3.4" />-->
     </ItemGroup>

--- a/src/Pie/Pie.csproj
+++ b/src/Pie/Pie.csproj
@@ -17,4 +17,10 @@
       <ProjectReference Include="..\Pie.ShaderCompiler\Pie.ShaderCompiler.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <!--<PackageReference Include="OpenTK.Graphics" Version="4.8.2" />-->
+      <PackageReference Include="Vortice.Direct3D11" Version="3.2.0" />
+      <!--<PackageReference Include="Vortice.DXGI" Version="3.3.4" />-->
+    </ItemGroup>
+
 </Project>

--- a/src/Pie/Pie.csproj
+++ b/src/Pie/Pie.csproj
@@ -14,12 +14,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Silk.NET.Direct3D.Compilers" Version="2.19.0" />
-      <PackageReference Include="Silk.NET.Direct3D11" Version="2.19.0" />
-      <PackageReference Include="Silk.NET.OpenGL" Version="2.19.0" />
-    </ItemGroup>
-
-    <ItemGroup>
       <ProjectReference Include="..\Pie.ShaderCompiler\Pie.ShaderCompiler.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
Replace Silk.NET with Vortice for Direct3D, and OpenTK for OpenGL.

This is mostly for maintainability improvements, especially in the Direct3D backend, which is currently difficult to write.