### PR TITLE
Replace Vortice with TerraFX

### DIFF
--- a/src/Pie/Direct3D11/D3D11BlendState.cs
+++ b/src/Pie/Direct3D11/D3D11BlendState.cs
@@ -1,35 +1,44 @@
 using System;
-using Vortice.Direct3D11;
+using System.Diagnostics.CodeAnalysis;
+using TerraFX.Interop.DirectX;
+using static TerraFX.Interop.DirectX.D3D11_BLEND;
+using static TerraFX.Interop.DirectX.D3D11_BLEND_OP;
+using static Pie.Direct3D11.DxUtils;
 
 namespace Pie.Direct3D11;
 
-internal sealed class D3D11BlendState : BlendState
+[SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
+internal sealed unsafe class D3D11BlendState : BlendState
 {
     public override bool IsDisposed { get; protected set; }
 
-    public ID3D11BlendState State;
+    public ID3D11BlendState* State;
     
-    public D3D11BlendState(ID3D11Device device, BlendStateDescription description)
+    public D3D11BlendState(ID3D11Device* device, BlendStateDescription description)
     {
         Description = description;
 
-        BlendDescription desc = new BlendDescription();
+        D3D11_BLEND_DESC desc = new();
         desc.IndependentBlendEnable = false;
         desc.AlphaToCoverageEnable = false;
-        desc.RenderTarget[0] = new RenderTargetBlendDescription()
+        desc.RenderTarget[0] = new()
         {
             BlendEnable = description.Enabled,
-            SourceBlend = GetBlendFromBlendType(description.Source),
-            DestinationBlend = GetBlendFromBlendType(description.Destination),
-            BlendOperation = GetOpFromOp(description.BlendOperation),
-            SourceBlendAlpha = GetBlendFromBlendType(description.SourceAlpha),
-            DestinationBlendAlpha = GetBlendFromBlendType(description.DestinationAlpha),
-            BlendOperationAlpha = GetOpFromOp(description.AlphaBlendOperation),
+            SrcBlend = GetBlendFromBlendType(description.Source),
+            DestBlend = GetBlendFromBlendType(description.Destination),
+            BlendOp = GetOpFromOp(description.BlendOperation),
+            SrcBlendAlpha = GetBlendFromBlendType(description.SourceAlpha),
+            DestBlendAlpha = GetBlendFromBlendType(description.DestinationAlpha),
+            BlendOpAlpha = GetOpFromOp(description.AlphaBlendOperation),
             // TODO: This should be a safe operation, as the two enums are compatible. But it's going to be better to not cast, so that should probably be done at some point.
-            RenderTargetWriteMask = (ColorWriteEnable) description.ColorWriteMask
+            RenderTargetWriteMask = (byte) description.ColorWriteMask
         };
 
-        State = device.CreateBlendState(desc);
+        ID3D11BlendState* state;
+        if (Failed(device->CreateBlendState(&desc, &state)))
+            throw new PieException("Failed to create blend state.");
+        
+        State = state;
     }
 
     public override BlendStateDescription Description { get; }
@@ -39,36 +48,36 @@ internal sealed class D3D11BlendState : BlendState
         if (IsDisposed)
             return;
         IsDisposed = true;
-        State.Dispose();
+        State->Release();
     }
 
-    private static Blend GetBlendFromBlendType(BlendType type)
+    private static D3D11_BLEND GetBlendFromBlendType(BlendType type)
     {
         return type switch
         {
-            BlendType.Zero => Blend.Zero,
-            BlendType.One => Blend.One,
-            BlendType.SrcColor => Blend.SourceColor,
-            BlendType.OneMinusSrcColor => Blend.InverseSourceColor,
-            BlendType.DestColor => Blend.DestinationColor,
-            BlendType.OneMinusDestColor => Blend.InverseDestinationColor,
-            BlendType.SrcAlpha => Blend.SourceAlpha,
-            BlendType.OneMinusSrcAlpha => Blend.InverseSourceAlpha,
-            BlendType.DestAlpha => Blend.DestinationAlpha,
-            BlendType.OneMinusDestAlpha => Blend.InverseDestinationAlpha,
+            BlendType.Zero => D3D11_BLEND_ZERO,
+            BlendType.One => D3D11_BLEND_ONE,
+            BlendType.SrcColor => D3D11_BLEND_SRC_COLOR,
+            BlendType.OneMinusSrcColor => D3D11_BLEND_INV_SRC_COLOR,
+            BlendType.DestColor => D3D11_BLEND_DEST_COLOR,
+            BlendType.OneMinusDestColor => D3D11_BLEND_INV_DEST_COLOR,
+            BlendType.SrcAlpha => D3D11_BLEND_SRC_ALPHA,
+            BlendType.OneMinusSrcAlpha => D3D11_BLEND_INV_SRC_ALPHA,
+            BlendType.DestAlpha => D3D11_BLEND_DEST_ALPHA,
+            BlendType.OneMinusDestAlpha => D3D11_BLEND_INV_DEST_ALPHA,
             _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
         };
     }
 
-    private static Vortice.Direct3D11.BlendOperation GetOpFromOp(BlendOperation operation)
+    private static D3D11_BLEND_OP GetOpFromOp(BlendOperation operation)
     {
         return operation switch
         {
-            BlendOperation.Add => Vortice.Direct3D11.BlendOperation.Add,
-            BlendOperation.Subtract => Vortice.Direct3D11.BlendOperation.Subtract,
-            BlendOperation.ReverseSubtract => Vortice.Direct3D11.BlendOperation.ReverseSubtract,
-            BlendOperation.Min => Vortice.Direct3D11.BlendOperation.Min,
-            BlendOperation.Max => Vortice.Direct3D11.BlendOperation.Max,
+            BlendOperation.Add => D3D11_BLEND_OP_ADD,
+            BlendOperation.Subtract => D3D11_BLEND_OP_SUBTRACT,
+            BlendOperation.ReverseSubtract => D3D11_BLEND_OP_REV_SUBTRACT,
+            BlendOperation.Min => D3D11_BLEND_OP_MIN,
+            BlendOperation.Max => D3D11_BLEND_OP_MAX,
             _ => throw new ArgumentOutOfRangeException(nameof(operation), operation, null)
         };
     }

--- a/src/Pie/Direct3D11/D3D11BlendState.cs
+++ b/src/Pie/Direct3D11/D3D11BlendState.cs
@@ -12,7 +12,7 @@ internal sealed unsafe class D3D11BlendState : BlendState
 {
     public override bool IsDisposed { get; protected set; }
 
-    public ID3D11BlendState* State;
+    public readonly ID3D11BlendState* State;
     
     public D3D11BlendState(ID3D11Device* device, BlendStateDescription description)
     {

--- a/src/Pie/Direct3D11/D3D11SamplerState.cs
+++ b/src/Pie/Direct3D11/D3D11SamplerState.cs
@@ -1,46 +1,59 @@
 using System;
-using Vortice.Direct3D11;
-using Vortice.Mathematics;
+using System.Diagnostics.CodeAnalysis;
+using TerraFX.Interop.DirectX;
+using static TerraFX.Interop.DirectX.D3D11_COMPARISON_FUNC;
+using static TerraFX.Interop.DirectX.D3D11_TEXTURE_ADDRESS_MODE;
+using static Pie.Direct3D11.DxUtils;
 
 namespace Pie.Direct3D11;
 
-internal sealed class D3D11SamplerState : SamplerState
+[SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
+internal sealed unsafe class D3D11SamplerState : SamplerState
 {
-    public ID3D11SamplerState State;
+    public readonly ID3D11SamplerState* State;
     
-    public D3D11SamplerState(ID3D11Device device, SamplerStateDescription description)
+    public D3D11SamplerState(ID3D11Device* device, SamplerStateDescription description)
     {
         Description = description;
         
-        Filter filter = description.Filter switch
+        D3D11_FILTER filter = description.Filter switch
         {
-            TextureFilter.Anisotropic => Filter.Anisotropic,
-            TextureFilter.MinMagMipPoint => Filter.MinMagMipPoint,
-            TextureFilter.MinMagPointMipLinear => Filter.MinMagPointMipLinear,
-            TextureFilter.MinPointMagLinearMipPoint => Filter.MinPointMagLinearMipPoint,
-            TextureFilter.MinPointMagMipLinear => Filter.MinPointMagMipLinear,
-            TextureFilter.MinLinearMagMipPoint => Filter.MinLinearMagMipPoint,
-            TextureFilter.MinLinearMagPointMipLinear => Filter.MinLinearMagPointMipLinear,
-            TextureFilter.MinMagLinearMipPoint => Filter.MinMagLinearMipPoint,
-            TextureFilter.MinMagMipLinear => Filter.MinMagMipLinear,
+            TextureFilter.Anisotropic => D3D11_FILTER.D3D11_FILTER_ANISOTROPIC,
+            TextureFilter.MinMagMipPoint => D3D11_FILTER.D3D11_FILTER_MIN_MAG_MIP_POINT,
+            TextureFilter.MinMagPointMipLinear => D3D11_FILTER.D3D11_FILTER_MIN_MAG_POINT_MIP_LINEAR,
+            TextureFilter.MinPointMagLinearMipPoint => D3D11_FILTER.D3D11_FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT,
+            TextureFilter.MinPointMagMipLinear => D3D11_FILTER.D3D11_FILTER_MIN_POINT_MAG_MIP_LINEAR,
+            TextureFilter.MinLinearMagMipPoint => D3D11_FILTER.D3D11_FILTER_MIN_LINEAR_MAG_MIP_POINT,
+            TextureFilter.MinLinearMagPointMipLinear => D3D11_FILTER.D3D11_FILTER_MIN_LINEAR_MAG_POINT_MIP_LINEAR,
+            TextureFilter.MinMagLinearMipPoint => D3D11_FILTER.D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT,
+            TextureFilter.MinMagMipLinear => D3D11_FILTER.D3D11_FILTER_MIN_MAG_MIP_LINEAR,
             _ => throw new ArgumentOutOfRangeException()
         };
-
-        SamplerDescription desc = new SamplerDescription()
+        
+        D3D11_SAMPLER_DESC desc = new()
         {
             Filter = filter,
             AddressU = GetAddressModeFromTextureAddress(description.AddressU),
             AddressV = GetAddressModeFromTextureAddress(description.AddressV),
             AddressW = GetAddressModeFromTextureAddress(description.AddressW),
             MipLODBias = 0,
-            MaxAnisotropy = description.MaxAnisotropy,
-            ComparisonFunc = Vortice.Direct3D11.ComparisonFunction.LessEqual,
+            MaxAnisotropy = (uint) description.MaxAnisotropy,
+            ComparisonFunc = D3D11_COMPARISON_LESS_EQUAL,
             MinLOD = description.MinLOD,
-            MaxLOD = description.MaxLOD,
-            BorderColor = new Color4(description.BorderColor.R, description.BorderColor.G, description.BorderColor.B, description.BorderColor.A)
+            MaxLOD = description.MaxLOD
         };
 
-        State = device.CreateSamplerState(desc);
+        // TODO: ???????????????????????????
+        desc.BorderColor[0] = description.BorderColor.R / 255f;
+        desc.BorderColor[1] = description.BorderColor.G / 255f;
+        desc.BorderColor[2] = description.BorderColor.B / 255f;
+        desc.BorderColor[3] = description.BorderColor.A / 255f;
+
+        ID3D11SamplerState* state;
+        if (Failed(device->CreateSamplerState(&desc, &state)))
+            throw new PieException("Failed to create sampler state.");
+
+        State = state;
     }
     
     public override bool IsDisposed { get; protected set; }
@@ -52,17 +65,17 @@ internal sealed class D3D11SamplerState : SamplerState
         if (IsDisposed)
             return;
         IsDisposed = true;
-        State.Dispose();
+        State->Release();
     }
 
-    private static TextureAddressMode GetAddressModeFromTextureAddress(TextureAddress address)
+    private static D3D11_TEXTURE_ADDRESS_MODE GetAddressModeFromTextureAddress(TextureAddress address)
     {
         return address switch
         {
-            TextureAddress.Repeat => TextureAddressMode.Wrap,
-            TextureAddress.Mirror => TextureAddressMode.Mirror,
-            TextureAddress.ClampToEdge => TextureAddressMode.Clamp,
-            TextureAddress.ClampToBorder => TextureAddressMode.Border,
+            TextureAddress.Repeat => D3D11_TEXTURE_ADDRESS_WRAP,
+            TextureAddress.Mirror => D3D11_TEXTURE_ADDRESS_MIRROR,
+            TextureAddress.ClampToEdge => D3D11_TEXTURE_ADDRESS_CLAMP,
+            TextureAddress.ClampToBorder => D3D11_TEXTURE_ADDRESS_BORDER,
             _ => throw new ArgumentOutOfRangeException(nameof(address), address, null)
         };
     }

--- a/src/Pie/Direct3D11/DxUtils.cs
+++ b/src/Pie/Direct3D11/DxUtils.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
 using static TerraFX.Interop.DirectX.D3D11_MAP;
 using static TerraFX.Interop.DirectX.DXGI_FORMAT;
 
@@ -10,7 +11,7 @@ namespace Pie.Direct3D11;
 [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
 internal static class DxUtils
 {
-    internal static DXGI_FORMAT ToDxgiFormat(this Format format, bool shaderResource)
+    public static DXGI_FORMAT ToDxgiFormat(this Format format, bool shaderResource)
     {
         return format switch
         {
@@ -77,7 +78,7 @@ internal static class DxUtils
         };
     }
 
-    internal static D3D11_MAP ToDx11MapMode(this MapMode mode)
+    public static D3D11_MAP ToDx11MapMode(this MapMode mode)
     {
         return mode switch
         {
@@ -89,6 +90,11 @@ internal static class DxUtils
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static uint CalcSubresource(uint mipSlice, uint arraySlice, uint mipLevels) =>
+    public static uint CalcSubresource(uint mipSlice, uint arraySlice, uint mipLevels) =>
         mipSlice + (arraySlice * mipLevels);
+
+    public static bool Failed(HRESULT hresult)
+    {
+        return hresult.FAILED;
+    }
 }

--- a/src/Pie/Direct3D11/DxUtils.cs
+++ b/src/Pie/Direct3D11/DxUtils.cs
@@ -1,84 +1,89 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using TerraFX.Interop.DirectX;
+using static TerraFX.Interop.DirectX.D3D11_MAP;
+using static TerraFX.Interop.DirectX.DXGI_FORMAT;
 
 namespace Pie.Direct3D11;
 
+[SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
 internal static class DxUtils
 {
-    internal static Vortice.DXGI.Format ToDxgiFormat(this Format format, bool shaderResource)
+    internal static DXGI_FORMAT ToDxgiFormat(this Format format, bool shaderResource)
     {
         return format switch
         {
-            Format.R8G8B8A8_UNorm => Vortice.DXGI.Format.R8G8B8A8_UNorm,
-            Format.B8G8R8A8_UNorm => Vortice.DXGI.Format.B8G8R8A8_UNorm,
-            Format.D24_UNorm_S8_UInt => shaderResource ? Vortice.DXGI.Format.R24G8_Typeless : Vortice.DXGI.Format.D24_UNorm_S8_UInt,
-            Format.R8_UNorm => Vortice.DXGI.Format.R8_UNorm,
-            Format.R8G8_UNorm => Vortice.DXGI.Format.R8G8_UNorm,
-            Format.R16G16B16A16_Float => Vortice.DXGI.Format.R16G16B16A16_Float,
-            Format.R32G32B32A32_Float => Vortice.DXGI.Format.R32G32B32A32_Float,
-            Format.R16G16B16A16_UNorm => Vortice.DXGI.Format.R16G16B16A16_UNorm,
-            Format.R16G16B16A16_SNorm => Vortice.DXGI.Format.R16G16B16A16_SNorm,
-            Format.R16G16B16A16_SInt => Vortice.DXGI.Format.R16G16B16A16_SInt,
-            Format.R16G16B16A16_UInt => Vortice.DXGI.Format.R16G16B16A16_UInt,
-            Format.R32G32_SInt => Vortice.DXGI.Format.R32G32_SInt,
-            Format.R32G32_UInt => Vortice.DXGI.Format.R32G32_UInt,
-            Format.R32G32_Float => Vortice.DXGI.Format.R32G32_Float,
-            Format.R32G32B32_SInt => Vortice.DXGI.Format.R32G32B32_SInt,
-            Format.R32G32B32_UInt => Vortice.DXGI.Format.R32G32B32_UInt,
-            Format.R32G32B32_Float => Vortice.DXGI.Format.R32G32B32_Float,
-            Format.R32G32B32A32_SInt => Vortice.DXGI.Format.R32G32B32A32_SInt,
-            Format.R32G32B32A32_UInt => Vortice.DXGI.Format.R32G32B32A32_UInt,
-            Format.R8_SNorm => Vortice.DXGI.Format.R8_SNorm,
-            Format.R8_SInt => Vortice.DXGI.Format.R8_SInt,
-            Format.R8_UInt => Vortice.DXGI.Format.R8_UInt,
-            Format.R8G8_SNorm => Vortice.DXGI.Format.R8G8_SNorm,
-            Format.R8G8_SInt => Vortice.DXGI.Format.R8G8_SInt,
-            Format.R8G8_UInt => Vortice.DXGI.Format.R8G8_UInt,
-            Format.R8G8B8A8_SNorm => Vortice.DXGI.Format.R8G8B8A8_SNorm,
-            Format.R8G8B8A8_SInt => Vortice.DXGI.Format.R8G8B8A8_SInt,
-            Format.R8G8B8A8_UInt => Vortice.DXGI.Format.R8G8B8A8_UInt,
-            Format.R16_UNorm => Vortice.DXGI.Format.R16_UNorm,
-            Format.R16_SNorm => Vortice.DXGI.Format.R16_SNorm,
-            Format.R16_SInt => Vortice.DXGI.Format.R16_SInt,
-            Format.R16_UInt => Vortice.DXGI.Format.R16_UInt,
-            Format.R16_Float => Vortice.DXGI.Format.R16_Float,
-            Format.R16G16_UNorm => Vortice.DXGI.Format.R16G16_UNorm,
-            Format.R16G16_SNorm => Vortice.DXGI.Format.R16G16_SNorm,
-            Format.R16G16_SInt => Vortice.DXGI.Format.R16G16_SInt,
-            Format.R16G16_UInt => Vortice.DXGI.Format.R16G16_UInt,
-            Format.R16G16_Float => Vortice.DXGI.Format.R16G16_Float,
-            Format.R32_SInt => Vortice.DXGI.Format.R32_SInt,
-            Format.R32_UInt => Vortice.DXGI.Format.R32_UInt,
-            Format.R32_Float => Vortice.DXGI.Format.R32_Float,
-            Format.R8G8B8A8_UNorm_SRgb => Vortice.DXGI.Format.R8G8B8A8_UNorm_SRgb,
-            Format.B8G8R8A8_UNorm_SRgb => Vortice.DXGI.Format.B8G8R8A8_UNorm_SRgb,
-            Format.D32_Float => shaderResource ? Vortice.DXGI.Format.R32_Typeless : Vortice.DXGI.Format.D32_Float,
-            Format.D16_UNorm => shaderResource ? Vortice.DXGI.Format.R16_Typeless : Vortice.DXGI.Format.D16_UNorm,
-            Format.BC1_UNorm => Vortice.DXGI.Format.BC1_UNorm,
-            Format.BC1_UNorm_SRgb => Vortice.DXGI.Format.BC1_UNorm_SRgb,
-            Format.BC2_UNorm => Vortice.DXGI.Format.BC2_UNorm,
-            Format.BC2_UNorm_SRgb => Vortice.DXGI.Format.BC2_UNorm_SRgb,
-            Format.BC3_UNorm => Vortice.DXGI.Format.BC3_UNorm,
-            Format.BC3_UNorm_SRgb => Vortice.DXGI.Format.BC3_UNorm_SRgb,
-            Format.BC4_UNorm => Vortice.DXGI.Format.BC4_UNorm,
-            Format.BC4_SNorm => Vortice.DXGI.Format.BC4_SNorm,
-            Format.BC5_UNorm => Vortice.DXGI.Format.BC5_UNorm,
-            Format.BC5_SNorm => Vortice.DXGI.Format.BC5_SNorm,
-            Format.BC6H_UF16 => Vortice.DXGI.Format.BC6H_Uf16,
-            Format.BC6H_SF16 => Vortice.DXGI.Format.BC6H_Uf16,
-            Format.BC7_UNorm => Vortice.DXGI.Format.BC7_UNorm,
-            Format.BC7_UNorm_SRgb => Vortice.DXGI.Format.BC7_UNorm_SRgb,
+            Format.R8G8B8A8_UNorm => DXGI_FORMAT_R8G8B8A8_UNORM,
+            Format.B8G8R8A8_UNorm => DXGI_FORMAT_B8G8R8A8_UNORM,
+            Format.D24_UNorm_S8_UInt => shaderResource ? DXGI_FORMAT_R24G8_TYPELESS : DXGI_FORMAT_D24_UNORM_S8_UINT,
+            Format.R8_UNorm => DXGI_FORMAT_R8_UNORM,
+            Format.R8G8_UNorm => DXGI_FORMAT_R8G8_UNORM,
+            Format.R16G16B16A16_Float => DXGI_FORMAT_R16G16B16A16_FLOAT,
+            Format.R32G32B32A32_Float => DXGI_FORMAT_R32G32B32A32_FLOAT,
+            Format.R16G16B16A16_UNorm => DXGI_FORMAT_R16G16B16A16_UNORM,
+            Format.R16G16B16A16_SNorm => DXGI_FORMAT_R16G16B16A16_SNORM,
+            Format.R16G16B16A16_SInt => DXGI_FORMAT_R16G16B16A16_SINT,
+            Format.R16G16B16A16_UInt => DXGI_FORMAT_R16G16B16A16_UINT,
+            Format.R32G32_SInt => DXGI_FORMAT_R32G32_SINT,
+            Format.R32G32_UInt => DXGI_FORMAT_R32G32_UINT,
+            Format.R32G32_Float => DXGI_FORMAT_R32G32_FLOAT,
+            Format.R32G32B32_SInt => DXGI_FORMAT_R32G32B32_SINT,
+            Format.R32G32B32_UInt => DXGI_FORMAT_R32G32B32_UINT,
+            Format.R32G32B32_Float => DXGI_FORMAT_R32G32B32_FLOAT,
+            Format.R32G32B32A32_SInt => DXGI_FORMAT_R32G32B32A32_SINT,
+            Format.R32G32B32A32_UInt => DXGI_FORMAT_R32G32B32A32_UINT,
+            Format.R8_SNorm => DXGI_FORMAT_R8_SNORM,
+            Format.R8_SInt => DXGI_FORMAT_R8_SINT,
+            Format.R8_UInt => DXGI_FORMAT_R8_UINT,
+            Format.R8G8_SNorm => DXGI_FORMAT_R8G8_SNORM,
+            Format.R8G8_SInt => DXGI_FORMAT_R8G8_SINT,
+            Format.R8G8_UInt => DXGI_FORMAT_R8G8_UINT,
+            Format.R8G8B8A8_SNorm => DXGI_FORMAT_R8G8B8A8_SNORM,
+            Format.R8G8B8A8_SInt => DXGI_FORMAT_R8G8B8A8_SINT,
+            Format.R8G8B8A8_UInt => DXGI_FORMAT_R8G8B8A8_UINT,
+            Format.R16_UNorm => DXGI_FORMAT_R16_UNORM,
+            Format.R16_SNorm => DXGI_FORMAT_R16_SNORM,
+            Format.R16_SInt => DXGI_FORMAT_R16_SINT,
+            Format.R16_UInt => DXGI_FORMAT_R16_UINT,
+            Format.R16_Float => DXGI_FORMAT_R16_FLOAT,
+            Format.R16G16_UNorm => DXGI_FORMAT_R16G16_UNORM,
+            Format.R16G16_SNorm => DXGI_FORMAT_R16G16_SNORM,
+            Format.R16G16_SInt => DXGI_FORMAT_R16G16_SINT,
+            Format.R16G16_UInt => DXGI_FORMAT_R16G16_UINT,
+            Format.R16G16_Float => DXGI_FORMAT_R16G16_FLOAT,
+            Format.R32_SInt => DXGI_FORMAT_R32_SINT,
+            Format.R32_UInt => DXGI_FORMAT_R32_UINT,
+            Format.R32_Float => DXGI_FORMAT_R32_FLOAT,
+            Format.R8G8B8A8_UNorm_SRgb => DXGI_FORMAT_R8G8B8A8_UNORM_SRGB,
+            Format.B8G8R8A8_UNorm_SRgb => DXGI_FORMAT_B8G8R8A8_UNORM_SRGB,
+            Format.D32_Float => shaderResource ? DXGI_FORMAT_R32_TYPELESS : DXGI_FORMAT_D32_FLOAT,
+            Format.D16_UNorm => shaderResource ? DXGI_FORMAT_R16_TYPELESS : DXGI_FORMAT_D16_UNORM,
+            Format.BC1_UNorm => DXGI_FORMAT_BC1_UNORM,
+            Format.BC1_UNorm_SRgb => DXGI_FORMAT_BC1_UNORM_SRGB,
+            Format.BC2_UNorm => DXGI_FORMAT_BC2_UNORM,
+            Format.BC2_UNorm_SRgb => DXGI_FORMAT_BC2_UNORM_SRGB,
+            Format.BC3_UNorm => DXGI_FORMAT_BC3_UNORM,
+            Format.BC3_UNorm_SRgb => DXGI_FORMAT_BC3_UNORM_SRGB,
+            Format.BC4_UNorm => DXGI_FORMAT_BC4_UNORM,
+            Format.BC4_SNorm => DXGI_FORMAT_BC4_SNORM,
+            Format.BC5_UNorm => DXGI_FORMAT_BC5_UNORM,
+            Format.BC5_SNorm => DXGI_FORMAT_BC5_SNORM,
+            Format.BC6H_UF16 => DXGI_FORMAT_BC6H_UF16,
+            Format.BC6H_SF16 => DXGI_FORMAT_BC6H_SF16,
+            Format.BC7_UNorm => DXGI_FORMAT_BC7_UNORM,
+            Format.BC7_UNorm_SRgb => DXGI_FORMAT_BC7_UNORM_SRGB,
             _ => throw new ArgumentOutOfRangeException(nameof(format), format, null)
         };
     }
 
-    internal static Vortice.Direct3D11.MapMode ToDx11MapMode(this MapMode mode)
+    internal static D3D11_MAP ToDx11MapMode(this MapMode mode)
     {
         return mode switch
         {
-            MapMode.Read => Vortice.Direct3D11.MapMode.Read,
-            MapMode.Write => Vortice.Direct3D11.MapMode.WriteDiscard,
-            MapMode.ReadWrite => Vortice.Direct3D11.MapMode.ReadWrite,
+            MapMode.Read => D3D11_MAP_READ,
+            MapMode.Write => D3D11_MAP_WRITE_DISCARD,
+            MapMode.ReadWrite => D3D11_MAP_READ_WRITE,
             _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
         };
     }

--- a/src/Pie/Pie.csproj
+++ b/src/Pie/Pie.csproj
@@ -20,8 +20,7 @@
     <ItemGroup>
       <!--<PackageReference Include="OpenTK.Graphics" Version="4.8.2" />-->
       <PackageReference Include="Silk.NET.OpenGL" Version="2.20.0" />
-      <PackageReference Include="Vortice.D3DCompiler" Version="3.3.4" />
-      <PackageReference Include="Vortice.Direct3D11" Version="3.3.4" />
+      <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.22621.6" />
       <!--<PackageReference Include="Vortice.DXGI" Version="3.3.4" />-->
     </ItemGroup>
 


### PR DESCRIPTION
After evaluating various D3D11 libraries, we're now looking at using TerraFX for D3D11 due to its completely raw nature. This is currently experemental and if it doesn't work out we will re-evaluate the options.